### PR TITLE
Shifted legend on line chart to below plot - better for small screens.

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -8,6 +8,7 @@ ggplot(dfRevenueBalance, aes(x=year,y=average_revenue_balance,color=area_name)) 
     axis.title.x = element_text(margin = margin(t = 12)),
     axis.title.y = element_text(margin = margin(r = 12)),
     axis.line = element_line( size = 1.0),
+    legend.position = 'top'
   ) +
   scale_y_continuous(
     labels = scales::number_format(accuracy = 1, big = ',', prefix='£')) +

--- a/server.R
+++ b/server.R
@@ -37,8 +37,8 @@ server <- function(input, output, session) {
 
   # Define server logic required to draw a histogram
   output$lineRevBal <- renderPlotly({
-    ggplotly(createAvgRevTimeSeries(reactiveRevBal(), input$selectArea)) %>% 
-      config(displayModeBar = F)%>%
+    ggplotly(createAvgRevTimeSeries(reactiveRevBal(), input$selectArea)) %>%
+      config(displayModeBar = F) %>%
       layout(legend = list(orientation = "h", x = 0, y = -0.2))
   })
 
@@ -52,9 +52,9 @@ server <- function(input, output, session) {
   })
 
   output$colBenchmark <- renderPlotly({
-    ggplotly(plotAvgRevBenchmark(reactiveBenchmark()) %>% 
-               config(displayModeBar = F),
-      height = 420
+    ggplotly(plotAvgRevBenchmark(reactiveBenchmark()) %>%
+      config(displayModeBar = F),
+    height = 420
     )
   })
 

--- a/server.R
+++ b/server.R
@@ -37,7 +37,9 @@ server <- function(input, output, session) {
 
   # Define server logic required to draw a histogram
   output$lineRevBal <- renderPlotly({
-    ggplotly(createAvgRevTimeSeries(reactiveRevBal(), input$selectArea))
+    ggplotly(createAvgRevTimeSeries(reactiveRevBal(), input$selectArea)) %>% 
+      config(displayModeBar = F)%>%
+      layout(legend = list(orientation = "h", x = 0, y = -0.2))
   })
 
   reactiveBenchmark <- reactive({
@@ -50,7 +52,8 @@ server <- function(input, output, session) {
   })
 
   output$colBenchmark <- renderPlotly({
-    ggplotly(plotAvgRevBenchmark(reactiveBenchmark()),
+    ggplotly(plotAvgRevBenchmark(reactiveBenchmark()) %>% 
+               config(displayModeBar = F),
       height = 420
     )
   })


### PR DESCRIPTION
Quick change to shift the legend and remove mode bar from plotly plots.