### PR TITLE
Edit CSS 

### DIFF
--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -26,10 +26,12 @@ a {
 
 a:hover {
   color:	#003078;
+  text-decoration: underline
 }
 
 a:visited {
   color: #4c2c92;
+  text-decoration: underline
 }
 
 

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -103,6 +103,9 @@ a:active {
 
 /* Tabs layout styling */
 
+.nav-tabs > li > a {
+  text-decoration: none
+}
 
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:focus,

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -21,6 +21,8 @@
 
 a {
   	color: #1d70b8;
+  	text-decoration: underline
+  	
 }
 
 a:hover {

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -122,76 +122,7 @@ a:active {
   background-color: #fff;
   text-decoration: none
 }
-/*
-.nav-tabs > li.active > a {
-  font-family: "GDS Transport", arial, sans-serif;
-  background-color: white;
-  border: none;
-  text-decoration: none;
-}
 
-.nav-tabs > li.active > a:hover,
-.nav-tabs > li.active > a:focus {
-  font-family: "GDS Transport", arial, sans-serif;
-  background-color: white;
-  border: none;
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.nav-tabs > li {
-  position: relative;
-  margin-right: 5px;
-  margin-bottom: 0;
-  margin-left: 0;
-  padding: 10px 20px;
-  float: left;
-  background-color: #f3f2f1;
-  text-align: center;
-}
-
-.nav-tabs > li.active {
-  position: relative;
-  margin-bottom: -1px;
-  padding-top: 14px;
-  padding-right: 19px;
-  padding-bottom: 16px;
-  padding-left: 19px;
-  border: 1px solid #b1b4b6;
-  border-bottom: 0;
-  background-color: #fff;
-}
-
-.nav-tabs > li > a {
-  font-family: "GDS Transport", arial, sans-serif !important;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-decoration: underline;
-  text-decoration-thickness: max(1px, 0.0625rem);
-  text-underline-offset: 0.1em;
-  display: inline-block;
-  margin-bottom: 10px;
-  color: #0b0c0c;
-  font-weight: 400;
-  font-size: 19px;
-}
-
-.nav-tabs > li > a:hover {
-  font-family: "GDS Transport", arial, sans-serif !important;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-decoration: underline;
-  text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
-  text-underline-offset: 0.1em;
-  display: inline-block;
-  margin-bottom: 10px;
-  color: #0b0c0c;
-  font-weight: 400;
-  font-size: 19px;
-  border-color: transparent;
-  background-color: transparent;
-}
-*/
 .well {
     min-height: 90vh;
     padding: 19px;

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -22,7 +22,6 @@
 a {
   	color: #1d70b8;
   	text-decoration: underline
-  	
 }
 
 a:hover {

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -21,17 +21,14 @@
 
 a {
   	color: #1d70b8;
-  	text-decoration: underline
 }
 
 a:hover {
   color:	#003078;
-  text-decoration: underline
 }
 
 a:visited {
   color: #4c2c92;
-  text-decoration: underline
 }
 
 
@@ -41,18 +38,22 @@ html {
 
 a {
   color: 	#1d70b8;
+  text-decoration: underline
 }
 
 a:hover {
   color: 	#003078;
+  text-decoration: underline
 }
 
 a:visited {
   color: 	#4c2c92;
+  text-decoration: underline
 }
 
 a:active {
   color: 	#0b0c0c;
+  text-decoration: underline
 }
 
 
@@ -74,6 +75,7 @@ a:active {
   color: #1d70b8;
   font-size: 15px;
   border-color: #1d70b8;
+  text-decoration: none
 }
 
 .nav-pills > li.active > a,
@@ -96,6 +98,7 @@ a:active {
   font-size: 15px;
   padding: 10px;
   border-left: 4px solid transparent;
+  text-decoration: none
 }
 
 /* Tabs layout styling */

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -103,11 +103,6 @@ a:active {
 
 /* Tabs layout styling */
 
-.tabbable > .tab-content {
-  padding: 30px 20px;
-  border: 1px solid #b1b4b6;
-  border-top: 0
-}
 
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:focus,
@@ -122,8 +117,9 @@ a:active {
   border: 1px solid #b1b4b6;
   border-bottom: 0;
   background-color: #fff;
+  text-decoration: none
 }
-
+/*
 .nav-tabs > li.active > a {
   font-family: "GDS Transport", arial, sans-serif;
   background-color: white;
@@ -204,7 +200,7 @@ a:active {
     box-shadow: inset 0 1px 1px rgb(0 0 0 / 5%);
     color: #fff;
 }
-
+*/
 
 /* Full screen plots */
 /* Adapted from https://stackoverflow.com/questions/69042546/is-there-a-way-to-create-a-full-screen-popup-window-of-a-plotly-chart-in-r */

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -188,7 +188,7 @@ a:active {
   border-color: transparent;
   background-color: transparent;
 }
-
+*/
 .well {
     min-height: 90vh;
     padding: 19px;
@@ -200,7 +200,7 @@ a:active {
     box-shadow: inset 0 1px 1px rgb(0 0 0 / 5%);
     color: #fff;
 }
-*/
+
 
 /* Full screen plots */
 /* Adapted from https://stackoverflow.com/questions/69042546/is-there-a-way-to-create-a-full-screen-popup-window-of-a-plotly-chart-in-r */


### PR DESCRIPTION
## Pull request overview

CSS edits to underline hyperlinks and restyle tabs

## Pull request checklist

Please check if your PR fulfils the following:
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?
TABS:
![image](https://user-images.githubusercontent.com/101197790/195822110-c95aa201-25e8-46e5-b65d-d94f819e49bb.png)
LINKS:
![image](https://user-images.githubusercontent.com/101197790/195822171-22dc46d2-5cde-40b7-a1b8-e6dd210da209.png)


## What is the new behaviour?
TABS:
![image](https://user-images.githubusercontent.com/101197790/195822265-f0eb74bb-f8dc-4da0-8ebb-5b45d403cd86.png)
LINKS:
![image](https://user-images.githubusercontent.com/101197790/195822320-be9bf40c-c086-4d5d-958f-64a710876d54.png)

## Anything else

I've commented out all of the tab styling in the css file & thought I should leave it in there but commented in case we ever need it. What do you think though? Deleting would be neater. 

ALSO the tab edits have in turn removed the box outline that surrounded the tab content. Are we happy with that too?
