### PR TITLE
valueBox customisation

### DIFF
--- a/R/dfe_template.R
+++ b/R/dfe_template.R
@@ -24,7 +24,7 @@ valueBox <- function(value, subtitle, icon = NULL, color = "aqua", width = 4,
   )
 }
 
-validColors <- c("blue")
+validColors <- c("blue","green","orange","purple")
 
 validateColor <- function(color) {
   if (color %in% validColors) {

--- a/R/dfe_template.R
+++ b/R/dfe_template.R
@@ -1,0 +1,36 @@
+# This file contains scripts which are intended to provide standard styling 
+# across dashboards. If you want to change anything in this script, please 
+# talk to the DfE Statistics Development team first.
+
+valueBox <- function(value, subtitle, icon = NULL, color = "aqua", width = 4,
+                     href = NULL)
+{
+  validateColor(color)
+  if (!is.null(icon)) tagAssert(icon, type = "i")
+  
+  boxContent <- div(class = paste0("small-box bg-", color),
+                    div(class = "inner",
+                        p(value,id="vboxhead"),
+                        p(subtitle,id="vboxdetail")
+                    ),
+                    if (!is.null(icon)) div(class = "icon-large", icon)
+  )
+  
+  if (!is.null(href))
+    boxContent <- a(href = href, boxContent)
+  
+  div(class = if (!is.null(width)) paste0("col-sm-", width),
+      boxContent
+  )
+}
+
+validColors <- c("blue")
+
+validateColor <- function(color) {
+  if (color %in% validColors) {
+    return(TRUE)
+  }
+  
+  stop("Invalid color: ", color, ". Valid colors are: ",
+       paste(validColors, collapse = ", "), ".")
+}

--- a/R/dfe_template.R
+++ b/R/dfe_template.R
@@ -24,7 +24,7 @@ valueBox <- function(value, subtitle, icon = NULL, color = "aqua", width = 4,
   )
 }
 
-validColors <- c("blue","green","orange","purple")
+validColors <- c("blue","green","orange","purple","white")
 
 validateColor <- function(color) {
   if (color %in% validColors) {

--- a/R/dfe_template.R
+++ b/R/dfe_template.R
@@ -24,7 +24,7 @@ valueBox <- function(value, subtitle, icon = NULL, color = "aqua", width = 4,
   )
 }
 
-validColors <- c("blue","green","orange","purple","white")
+validColors <- c("blue","dark-blue","green","orange","purple","white")
 
 validateColor <- function(color) {
   if (color %in% validColors) {

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -191,6 +191,10 @@ a:active {
      color: #ffffff;
 }
 
+.small-box.bg-dark-blue{
+     background-color: 	#12436D !important; 
+     color: #ffffff;
+}
 
 #ss-connect-dialog { display: none !important; }
 #shiny-disconnected-overlay { display: none !important; }
@@ -270,7 +274,6 @@ a:active {
 
 #vboxhead {
   text-align: left;
-  color: white;
   font-weight: bold;
   font-size: 56px;
 }

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -163,6 +163,12 @@ a:active {
     color: #ffffff;
 }
 
+.small-box.bg-white {
+    background-color: 	#ffffff !important;
+    color: #000000;
+}
+
+
 .small-box.bg-blue{
      background-color: #1d70b8 !important; 
      color: #ffffff;
@@ -271,7 +277,6 @@ a:active {
 
 #vboxdetail {
   text-align: left;
-  color: white;
   font-weight: bold;
   font-size: 16px;
 }

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -261,3 +261,17 @@ a:active {
         vertical-align: top !important;
     }
 }
+
+#vboxhead {
+  text-align: left;
+  color: white;
+  font-weight: bold;
+  font-size: 56px;
+}
+
+#vboxdetail {
+  text-align: left;
+  color: white;
+  font-weight: bold;
+  font-size: 16px;
+}


### PR DESCRIPTION
## Pull request overview

Brought the valuBox code into the template. Main motivation was for accessibility as the h3() element was used for the valubox title text, but that messes up the header flow on the page. Secondary motivation is that it means we can remove the remaining bad colour options from the shiny version (for reasons of both taste and accessibility).