### PR TITLE
Cookie authorisation

### DIFF
--- a/.github/workflows/deploy-shiny.yaml
+++ b/.github/workflows/deploy-shiny.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - development
 
 name: deploy-shiny
 

--- a/.github/workflows/deploy-shiny.yaml
+++ b/.github/workflows/deploy-shiny.yaml
@@ -31,6 +31,16 @@ jobs:
           r-version: 4.2.1
           use-public-rspm: true
 
+      - name: Set env vars (dev)
+        if: endsWith(github.ref, '/development')
+        run: |
+          echo "SHINYAPP_NAME='dev-dfe-shiny-template'" >> $GITHUB_ENV
+      - name: Set env vars (prod)
+        if: endsWith(github.ref, '/main')
+        run: |
+          echo "SHINYAPP_NAME='dfe-shiny-template'">> $GITHUB_ENV
+          echo "SHINYAPP_OVERFLOW_NAME='dfe-shiny-template-overflow'">> $GITHUB_ENV
+
       - name: Cache R packages
         if: runner.os != 'Windows'
         uses: actions/cache@v1
@@ -66,5 +76,8 @@ jobs:
         run: >
           Rscript
           -e "rsconnect::setAccountInfo(name = 'department-for-education', token = '${{secrets.SHINYAPPS_TOKEN}}', secret = '${{secrets.SHINYAPPS_SECRET}}')"
-          -e "rsconnect::deployApp(appName='dfe-shiny-template')"
-          -e "rsconnect::deployApp(appName='dfe-shiny-template-overflow')"
+          -e "rsconnect::deployApp(appName=${{env.SHINYAPP_NAME}})"
+        if: endsWith(github.ref, '/main')
+        run: >
+          Rscript
+          -e "rsconnect::deployApp(appName=${{env.SHINYAPP_OVERFLOW_NAME}})"

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -7,11 +7,7 @@ homepage_panel <- function() {
           12,
           h1("DfE Analytical Services R-Shiny data dashboard template (h1)"),
           br(),
-          br(),
-          textInput("name_set", "What is your name?"),
-          actionButton("save", "Save cookie"),
-          actionButton("remove", "remove cookie"),
-          uiOutput("name_get")
+          br()
         ),
 
         ## Left panel -------------------------------------------------------
@@ -64,6 +60,12 @@ homepage_panel <- function() {
               )
             )
           )
+        ),
+        column(
+          12,
+          textOutput("cookie_status"),
+          actionButton("remove", "Reset consent"),
+          
         )
       )
     )

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -60,12 +60,6 @@ homepage_panel <- function() {
               )
             )
           )
-        ),
-        column(
-          12,
-          textOutput("cookie_status"),
-          actionButton("remove", "Reset consent"),
-          
         )
       )
     )

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -7,7 +7,11 @@ homepage_panel <- function() {
           12,
           h1("DfE Analytical Services R-Shiny data dashboard template (h1)"),
           br(),
-          br()
+          br(),
+          textInput("name_set", "What is your name?"),
+          actionButton("save", "Save cookie"),
+          actionButton("remove", "remove cookie"),
+          uiOutput("name_get")
         ),
 
         ## Left panel -------------------------------------------------------

--- a/R/standard_panels.R
+++ b/R/standard_panels.R
@@ -66,12 +66,13 @@ support_links <- function() {
           "The source code for this dashboard is available in our ",
           a(href = "https://github.com/dfe-analytical-services/shiny-template", "GitHub repository", .noWS = c("after")),
           ".",
-          br(),
-          br(),
-          br(),
-          br(),
-          br(),
           br()
+        ),
+        column(
+          12,
+          h2("Use of cookies"),
+          textOutput("cookie_status"),
+          actionButton("remove", "Reset cookie consent"),
         )
       )
     )

--- a/global.R
+++ b/global.R
@@ -24,6 +24,7 @@ shhh(library(plotly))
 shhh(library(DT))
 shhh(library(xfun))
 shhh(library(metathis))
+shhh(library(shinyalert))
 # shhh(library(shinya11y))
 
 # Functions ---------------------------------------------------------------------------------

--- a/global.R
+++ b/global.R
@@ -87,7 +87,7 @@ site_overflow <- "https://department-for-education.shinyapps.io/dfe-shiny-templa
 sites_list <- c(site_primary, site_overflow) # We can add further mirrors where necessary. Each one can generally handle about 2,500 users simultaneously
 ees_pub_name <- "Statistical publication" # Update this with your parent publication name (e.g. the EES publication)
 ees_publication <- "https://explore-education-statistics.service.gov.uk/find-statistics/" # Update with parent publication link
-google_analytics_key <- 'Z967JJVQQX'
+google_analytics_key <- "Z967JJVQQX"
 
 
 source("R/support_links.R")

--- a/global.R
+++ b/global.R
@@ -87,6 +87,8 @@ site_overflow <- "https://department-for-education.shinyapps.io/dfe-shiny-templa
 sites_list <- c(site_primary, site_overflow) # We can add further mirrors where necessary. Each one can generally handle about 2,500 users simultaneously
 ees_pub_name <- "Statistical publication" # Update this with your parent publication name (e.g. the EES publication)
 ees_publication <- "https://explore-education-statistics.service.gov.uk/find-statistics/" # Update with parent publication link
+google_analytics_key <- 'Z967JJVQQX'
+
 
 source("R/support_links.R")
 source("R/read_data.R")

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -59,11 +59,3 @@ The tracking number below MUST be replaced with a unique number, contact the sta
   
 </script>
       
-      
-<script>
-  function consentGranted() {
-    gtag('consent', 'update', {
-      'ad_storage': 'granted'
-    });
-  }
-</script>

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -2,6 +2,12 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Z967JJVQQX"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
+    function getCookie(name) {
+      let matches = document.cookie.match(new RegExp(
+        "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
+      ));
+      return matches ? decodeURIComponent(matches[1]) : undefined;
+    }
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     
@@ -9,6 +15,11 @@
 The tracking number below MUST be replaced with a unique number, contact the statistics development team to set this up. 
 */
     gtag('config', 'G-Z967JJVQQX');
+    
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': getCookie("dfe_analytics")
+    });
   
   $(document).on('change', 'select#selectPhase', function(e) {
     gtag('event', 'select phase', {'event_category' : 'choose Phase',

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -1,26 +1,30 @@
+<script>
+// Define dataLayer and the gtag function.
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+
+// Default ad_storage to 'denied' as a placeholder
+// Determine actual values based on your own requirements
+gtag('consent', 'default', {
+  'ad_storage': 'denied',
+  'analytics_storage': 'denied'
+});
+</script>
+
 <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Z967JJVQQX"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function getCookie(name) {
-      let matches = document.cookie.match(new RegExp(
-        "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
-      ));
-      return matches ? decodeURIComponent(matches[1]) : undefined;
-    }
     function gtag(){dataLayer.push(arguments);}
+
     gtag('js', new Date());
     
 /*
 The tracking number below MUST be replaced with a unique number, contact the statistics development team to set this up. 
 */
-    gtag('config', 'G-Z967JJVQQX');
-    
-    gtag('consent', 'default', {
-      'ad_storage': 'denied',
-      'analytics_storage': getCookie("dfe_analytics")
-    });
+  gtag('config', 'G-Z967JJVQQX');
   
+
   $(document).on('change', 'select#selectPhase', function(e) {
     gtag('event', 'select phase', {'event_category' : 'choose Phase',
     'event_label' : document.querySelector('select#selectPhase').value
@@ -51,6 +55,15 @@ The tracking number below MUST be replaced with a unique number, contact the sta
     });
   });
   
+
   
 </script>
       
+      
+<script>
+  function consentGranted() {
+    gtag('consent', 'update', {
+      'ad_storage': 'granted'
+    });
+  }
+</script>

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.2.1",
+    "Version": "4.2.2",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -976,6 +976,19 @@
         "shiny"
       ]
     },
+    "shinyalert": {
+      "Package": "shinyalert",
+      "Version": "3.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2fd42421abd79dcaf0855fa1d21599a3",
+      "Requirements": [
+        "htmltools",
+        "knitr",
+        "shiny",
+        "uuid"
+      ]
+    },
     "shinydashboard": {
       "Package": "shinydashboard",
       "Version": "0.7.2",
@@ -1175,6 +1188,14 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "c9c462b759a5cc844ae25b5942654d13",
+      "Requirements": []
+    },
+    "uuid": {
+      "Package": "uuid",
+      "Version": "1.1-0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f1cb46c157d080b729159d407be83496",
       "Requirements": []
     },
     "vctrs": {

--- a/server.R
+++ b/server.R
@@ -27,7 +27,7 @@ server <- function(input, output, session) {
   show("app-content")
 
   # output if cookie is unspecified
-  observeEvent(input$cookies,{
+  observeEvent(input$cookies, {
     if (!is.null(input$cookies)) {
       if (!("dfe_analytics" %in% names(input$cookies))) {
         shinyalert(

--- a/server.R
+++ b/server.R
@@ -27,35 +27,36 @@ server <- function(input, output, session) {
   show("app-content")
 
   # output if cookie is unspecified
-  observe({
-    if(!is.null(input$cookies)){
-      if(is.null(input$cookies$dfe_analytics)){
-      shinyalert(
-        inputId = "cookie_consent",
-        title = "Cookie consent",
-        text = "This site uses cookies to record traffic flow using Google Analytics",
-        size = "s", 
-        closeOnEsc = TRUE,
-        closeOnClickOutside = FALSE,
-        html = FALSE,
-        type = "",
-        showConfirmButton = TRUE,
-        showCancelButton = TRUE,
-        confirmButtonText = "Accept",
-        confirmButtonCol = "#AEDEF4",
-        timer = 0,
-        imageUrl = "",
-        animation = TRUE
-      )} else {
+  observeEvent(input$cookies,{
+    if (!is.null(input$cookies)) {
+      if (!("dfe_analytics" %in% names(input$cookies))) {
+        shinyalert(
+          inputId = "cookie_consent",
+          title = "Cookie consent",
+          text = "This site uses cookies to record traffic flow using Google Analytics",
+          size = "s",
+          closeOnEsc = TRUE,
+          closeOnClickOutside = FALSE,
+          html = FALSE,
+          type = "",
+          showConfirmButton = TRUE,
+          showCancelButton = TRUE,
+          confirmButtonText = "Accept",
+          confirmButtonCol = "#AEDEF4",
+          timer = 0,
+          imageUrl = "",
+          animation = TRUE
+        )
+      } else {
         msg <- list(
-          name = "dfe_analytics", 
+          name = "dfe_analytics",
           value = input$cookies$dfe_analytics
         )
         session$sendCustomMessage("analytics-consent", msg)
-        if("cookies" %in% names(input)){
-          if("dfe_analytics" %in% names(input$cookies)){
-            if(input$cookies$dfe_analytics=='denied'){
-              ga_msg <- list(name = paste0("_ga_",google_analytics_key))
+        if ("cookies" %in% names(input)) {
+          if ("dfe_analytics" %in% names(input$cookies)) {
+            if (input$cookies$dfe_analytics == "denied") {
+              ga_msg <- list(name = paste0("_ga_", google_analytics_key))
               session$sendCustomMessage("cookie-remove", ga_msg)
             }
           }
@@ -64,54 +65,52 @@ server <- function(input, output, session) {
     }
   })
 
-  observeEvent(input$cookie_consent,{
+  observeEvent(input$cookie_consent, {
     msg <- list(
-      name = "dfe_analytics", 
-      value = ifelse(input$cookie_consent,'granted','denied')
+      name = "dfe_analytics",
+      value = ifelse(input$cookie_consent, "granted", "denied")
     )
     session$sendCustomMessage("cookie-set", msg)
     session$sendCustomMessage("analytics-consent", msg)
-    if("cookies" %in% names(input)){
-      if("dfe_analytics" %in% names(input$cookies)){
-        if(input$cookies$dfe_analytics=='denied'){
-          ga_msg <- list(name = paste0("_ga_",google_analytics_key))
+    if ("cookies" %in% names(input)) {
+      if ("dfe_analytics" %in% names(input$cookies)) {
+        if (input$cookies$dfe_analytics == "denied") {
+          ga_msg <- list(name = paste0("_ga_", google_analytics_key))
           session$sendCustomMessage("cookie-remove", ga_msg)
         }
       }
     }
-  }
-  )
-  
+  })
+
   observeEvent(input$remove, {
-    msg <- list(name = "dfe_analytics", value='denied')
+    msg <- list(name = "dfe_analytics", value = "denied")
     session$sendCustomMessage("cookie-remove", msg)
     session$sendCustomMessage("analytics-consent", msg)
-    ga_msg <- list(name = paste0("_ga_",google_analytics_key))
-    session$sendCustomMessage("cookie-remove", ga_msg)
   })
-  
+
   cookies_data <- reactive({
     input$cookies
   })
-  
+
   output$cookie_status <- renderText({
-    if("cookies" %in% names(input)){
-      if("dfe_analytics" %in% names(input$cookies)){
-        if(input$cookies$dfe_analytics=="granted"){
-      "Cookies have been accepted."
-    } else {
-      "Cookies have been rejected."
-    }
+    cookie_text_stem <- "To better understand the reach of our dashboard tools, this site uses cookies to identify numbers of unique users as part of Google Analytics. You have chosen to"
+    cookie_text_tail <- "the use of cookies on this website."
+    if ("cookies" %in% names(input)) {
+      if ("dfe_analytics" %in% names(input$cookies)) {
+        if (input$cookies$dfe_analytics == "granted") {
+          paste(cookie_text_stem, "accept", cookie_text_tail)
+        } else {
+          paste(cookie_text_stem, "reject", cookie_text_tail)
         }
+      }
     } else {
       "Cookies consent has not been confirmed."
     }
-    }
-)
-  
+  })
 
-#  output$cookie_status <- renderText(as.character(input$cookies))
-  
+
+  #  output$cookie_status <- renderText(as.character(input$cookies))
+
   # Simple server stuff goes here ------------------------------------------------------------
   reactiveRevBal <- reactive({
     dfRevBal %>% filter(
@@ -314,5 +313,3 @@ server <- function(input, output, session) {
     stopApp()
   })
 }
-
-

--- a/server.R
+++ b/server.R
@@ -52,8 +52,15 @@ server <- function(input, output, session) {
           value = input$cookies$dfe_analytics
         )
         session$sendCustomMessage("analytics-consent", msg)
+        if("cookies" %in% names(input)){
+          if("dfe_analytics" %in% names(input$cookies)){
+            if(input$cookies$dfe_analytics=='denied'){
+              ga_msg <- list(name = paste0("_ga_",google_analytics_key))
+              session$sendCustomMessage("cookie-remove", ga_msg)
+            }
+          }
+        }
       }
-      
     }
   })
 
@@ -64,6 +71,14 @@ server <- function(input, output, session) {
     )
     session$sendCustomMessage("cookie-set", msg)
     session$sendCustomMessage("analytics-consent", msg)
+    if("cookies" %in% names(input)){
+      if("dfe_analytics" %in% names(input$cookies)){
+        if(input$cookies$dfe_analytics=='denied'){
+          ga_msg <- list(name = paste0("_ga_",google_analytics_key))
+          session$sendCustomMessage("cookie-remove", ga_msg)
+        }
+      }
+    }
   }
   )
   
@@ -71,6 +86,8 @@ server <- function(input, output, session) {
     msg <- list(name = "dfe_analytics", value='denied')
     session$sendCustomMessage("cookie-remove", msg)
     session$sendCustomMessage("analytics-consent", msg)
+    ga_msg <- list(name = paste0("_ga_",google_analytics_key))
+    session$sendCustomMessage("cookie-remove", ga_msg)
   })
   
   cookies_data <- reactive({

--- a/server.R
+++ b/server.R
@@ -26,6 +26,44 @@ server <- function(input, output, session) {
   hide(id = "loading-content", anim = TRUE, animType = "fade")
   show("app-content")
 
+  # Handle the cookie consent ----------------------------------------------------------------
+  observeEvent(input$save, {
+    msg <- list(
+      name = "name", value = input$name_set
+    )
+    
+    if(input$name_set != "")
+      session$sendCustomMessage("cookie-set", msg)
+  })
+  
+  # delete
+  observeEvent(input$remove, {
+    msg <- list(name = "name")
+    session$sendCustomMessage("cookie-remove", msg)
+  })
+  
+  # output if cookie is unspecified
+  observe(
+    if(is.null(input$cookies$name)){
+      shinyalert(
+        title = "Cookie consent",
+        text = "This site uses cookies to record traffic flow using Google Analytics",
+        size = "s", 
+        closeOnEsc = TRUE,
+        closeOnClickOutside = FALSE,
+        html = FALSE,
+        type = "",
+        showConfirmButton = TRUE,
+        showCancelButton = TRUE,
+        confirmButtonText = "Accept",
+        confirmButtonCol = "#AEDEF4",
+        timer = 0,
+        imageUrl = "",
+        animation = TRUE
+      )}
+    )
+
+    
   # Simple server stuff goes here ------------------------------------------------------------
   reactiveRevBal <- reactive({
     dfRevBal %>% filter(

--- a/tests/shinytest/initial_load_test-expected/001.json
+++ b/tests/shinytest/initial_load_test-expected/001.json
@@ -1,7 +1,11 @@
 {
   "input": {
+    "cookies": {
+
+    },
     "link_to_app_content_tab": 0,
     "navlistPanel": "Homepage",
+    "remove": 0,
     "selectArea": "England",
     "selectBenchLAs": null,
     "selectPhase": "All LA maintained schools",

--- a/ui.R
+++ b/ui.R
@@ -82,6 +82,17 @@ ui <- function(input, output, session) {
     shinyjs::useShinyjs(),
     customDisconnectMessage(),
     useShinydashboard(),
+    # Setting up cookie consent based on a cookie recording the consent:
+    # https://book.javascript-for-r.com/shiny-cookies.html
+    tags$head(
+      tags$script(
+        src = paste0(
+          "https://cdn.jsdelivr.net/npm/js-cookie@rc/",
+          "dist/js.cookie.min.js"
+        )
+      ),
+      tags$script(src = "cookie-consent.js")
+    ),
     tags$head(includeHTML(("google-analytics.html"))),
     tags$head(
       tags$link(

--- a/ui.R
+++ b/ui.R
@@ -65,7 +65,7 @@ ui <- function(input, output, session) {
         href = "dfefavicon.png"
       ),
       # Add title for browser tabs
-      tags$title("DfE Shiny Template")
+      tags$title("DfE Shiny Template - Testing - no analytics")
     ),
     tags$html(lang = "en"),
     # Add meta description for search engines

--- a/www/cookie-consent.js
+++ b/www/cookie-consent.js
@@ -1,0 +1,18 @@
+function getCookies(){
+  var res = Cookies.get();
+  Shiny.setInputValue('cookies', res);
+}
+
+Shiny.addCustomMessageHandler('cookie-set', function(msg){
+  Cookies.set(msg.name, msg.value);
+  getCookies();
+})
+
+Shiny.addCustomMessageHandler('cookie-remove', function(msg){
+  Cookies.remove(msg.name);
+  getCookies();
+})
+
+$(document).on('shiny:connected', function(ev){
+  getCookies();
+})

--- a/www/cookie-consent.js
+++ b/www/cookie-consent.js
@@ -16,3 +16,11 @@ Shiny.addCustomMessageHandler('cookie-remove', function(msg){
 $(document).on('shiny:connected', function(ev){
   getCookies();
 })
+
+Shiny.addCustomMessageHandler('analytics-consent', function(msg){
+  gtag('consent', 'update', {
+    'analytics_storage': msg.value
+  });
+})
+
+


### PR DESCRIPTION
## Pull request overview

### Cookie management
This implements a cookie authorisation solution that allows the user to decide whether to allow a cookie to be used to track them as a unique user for the Google Analytics.

The logic flow is as follows:

- If permission has not been granted when a user loads the app, a pop-up appears asking if the consent to cookies for use in Google Analytics. The result is itself stored in a cookie called dfe_analytics with a value set to "denied" or "granted".
- If dfe_analytics is set to granted, the google analytics cookie is created as soon as the user starts navigating around the dashboard. If it's set to denied, the cookie is not created.
- The user can reset their choice on the Support and Feedback panel. If they click the button, the cookie dfe_analytics is removed and the pop-up reappears.
- If the user elects at this point to reject cookies, the google analytics cookie is removed.

So, two cookies are involved, one to log the user preference on cookies (`dfe_analytics`) and one to track the user as a unique user (`_ga_<ga_app_id>`) for GA.

I currently have the `dfe_analytics` cookie set to expire when the browser is closed down (needs to be _all_ windows of the specific browser) to make testing easier. Would maybe change this to a few months once we're ready to use it in anger.

The cookie permissions can be reset on the Support and feedback page as shown in the screen grab below.

![image](https://user-images.githubusercontent.com/230859/210586748-15a162de-93ef-400f-96c8-92be4faedbc6.png)

### Deploy to development
I've also added in a deploy to development in the deploy yaml. This should deploy to `/dev-dfe-shiny-template` when it gets merged into the development branch on the remote GitHub repo.


## Testing

I've generally been testing by refreshing the _All cookies and site data_ panel in the browser settings. For the local run, you cam access the stored cookies here:
[edge://settings/cookies/detail?site=127.0.0.1](edge://settings/cookies/detail?site=127.0.0.1)

This is what it should look like when the user rejects cookies:
![image](https://user-images.githubusercontent.com/230859/208947091-b8ca8e7f-2573-49a3-bc79-95defa56c032.png)

And here's what it looks like when the cookie gets accepted:
![image](https://user-images.githubusercontent.com/230859/208947439-2c9534ef-a573-4849-8712-906f5b831dea.png)

## Extra info

Note that all the GA cookies across DfE dashboards get stored against the top level domain _shinyapps.io_. So once we add the cookie consent cookie, `dfe_analytics`, that should be visible as a cookie (once it's created for a given user) to _all_ DfE dashboards on shinyapps.io. So the permission should only need setting once by a user and then apply across all dashboards (including the _tiny-shiny_ ones).

![image](https://user-images.githubusercontent.com/230859/208950469-7720ef6b-35ea-4989-8770-5c83a66b019c.png)
