### PR TITLE
Collapse dropdown box into dev

### DIFF
--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -83,7 +83,7 @@ dashboard_panel <- function() {
         ),
         column(
           width = 12,
-          expandable(inputId = 'details', label = 'Expand me', help_text = 'Dropdowns here'),
+          expandable(inputId = 'details', label = 'Expand to view dropdown options', help_text = 'Dropdowns here'),
           # div(id = "div_a",
           #   class = "well",
           #   style = "min-height: 100%; height: 100%; overflow-y: visible",

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -85,8 +85,8 @@ dashboard_panel <- function() {
           width = 12,
           expandable(inputId = 'details', label = 'Expand to view dropdown options', contents =
           div(id = "div_a",
-            class = "well",
-            style = "min-height: 100%; height: 100%; overflow-y: visible",
+            # class = "well",
+            # style = "min-height: 100%; height: 100%; overflow-y: visible",
             gov_row(
               column(
                 width = 6,

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -83,38 +83,38 @@ dashboard_panel <- function() {
         ),
         column(
           width = 12,
-          expandable(inputId = 'details', label = 'Expand to view dropdown options', help_text = 'Dropdowns here'),
-          # div(id = "div_a",
-          #   class = "well",
-          #   style = "min-height: 100%; height: 100%; overflow-y: visible",
-          #   gov_row(
-          #     column(
-          #       width = 6,
-          #       selectizeInput("selectPhase",
-          #         "Select a school phase",
-          #         choices = choicesPhase
-          #       )
-          #     ),
-          #     column(
-          #       width = 6,
-          #       selectizeInput(
-          #         inputId = "selectArea",
-          #         label = "Choose an area:",
-          #         choices = choicesAreas$area_name
-          #       )
-          #     ),
-          #     column(
-          #       width = 12,
-          #       paste("Download the underlying data for this dashboard:"), br(),
-          #       downloadButton(
-          #         outputId = "download_data",
-          #         label = "Download data",
-          #         icon = shiny::icon("download"),
-          #         class = "downloadButton"
-          #       )
-          #     )
-          #   )
-          # )
+          expandable(inputId = 'details', label = 'Expand to view dropdown options', contents =
+          div(id = "div_a",
+            class = "well",
+            style = "min-height: 100%; height: 100%; overflow-y: visible",
+            gov_row(
+              column(
+                width = 6,
+                selectizeInput("selectPhase",
+                  "Select a school phase",
+                  choices = choicesPhase
+                )
+              ),
+              column(
+                width = 6,
+                selectizeInput(
+                  inputId = "selectArea",
+                  label = "Choose an area:",
+                  choices = choicesAreas$area_name
+                )
+              ),
+              column(
+                width = 12,
+                paste("Download the underlying data for this dashboard:"), br(),
+                downloadButton(
+                  outputId = "download_data",
+                  label = "Download data",
+                  icon = shiny::icon("download"),
+                  class = "downloadButton"
+                )
+              )
+            )
+          )),
         ),
         column(
           width = 12,

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -83,38 +83,41 @@ dashboard_panel <- function() {
         ),
         column(
           width = 12,
-          expandable(inputId = 'details', label = textOutput('dropdown_label'), contents =
-          div(id = "div_a",
-            # class = "well",
-            # style = "min-height: 100%; height: 100%; overflow-y: visible",
-            gov_row(
-              column(
-                width = 6,
-                selectizeInput("selectPhase",
-                  "Select a school phase",
-                  choices = choicesPhase
-                )
-              ),
-              column(
-                width = 6,
-                selectizeInput(
-                  inputId = "selectArea",
-                  label = "Choose an area:",
-                  choices = choicesAreas$area_name
-                )
-              ),
-              column(
-                width = 12,
-                paste("Download the underlying data for this dashboard:"), br(),
-                downloadButton(
-                  outputId = "download_data",
-                  label = "Download data",
-                  icon = shiny::icon("download"),
-                  class = "downloadButton"
+          expandable(
+            inputId = "details", label = textOutput("dropdown_label"), contents =
+              div(
+                id = "div_a",
+                # class = "well",
+                # style = "min-height: 100%; height: 100%; overflow-y: visible",
+                gov_row(
+                  column(
+                    width = 6,
+                    selectizeInput("selectPhase",
+                      "Select a school phase",
+                      choices = choicesPhase
+                    )
+                  ),
+                  column(
+                    width = 6,
+                    selectizeInput(
+                      inputId = "selectArea",
+                      label = "Choose an area:",
+                      choices = choicesAreas$area_name
+                    )
+                  ),
+                  column(
+                    width = 12,
+                    paste("Download the underlying data for this dashboard:"), br(),
+                    downloadButton(
+                      outputId = "download_data",
+                      label = "Download data",
+                      icon = shiny::icon("download"),
+                      class = "downloadButton"
+                    )
+                  )
                 )
               )
-            )
-          )),
+          ),
         ),
         column(
           width = 12,

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -83,7 +83,8 @@ dashboard_panel <- function() {
         ),
         column(
           width = 12,
-          div(
+          actionButton(inputId = "go",label = "Button"),
+          div(id = "div_a",
             class = "well",
             style = "min-height: 100%; height: 100%; overflow-y: visible",
             gov_row(

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -83,7 +83,7 @@ dashboard_panel <- function() {
         ),
         column(
           width = 12,
-          expandable(inputId = 'details', label = 'Expand to view dropdown options', contents =
+          expandable(inputId = 'details', label = textOutput('dropdown_label'), contents =
           div(id = "div_a",
             # class = "well",
             # style = "min-height: 100%; height: 100%; overflow-y: visible",

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -83,38 +83,38 @@ dashboard_panel <- function() {
         ),
         column(
           width = 12,
-          actionButton(inputId = "go",label = "Button"),
-          div(id = "div_a",
-            class = "well",
-            style = "min-height: 100%; height: 100%; overflow-y: visible",
-            gov_row(
-              column(
-                width = 6,
-                selectizeInput("selectPhase",
-                  "Select a school phase",
-                  choices = choicesPhase
-                )
-              ),
-              column(
-                width = 6,
-                selectizeInput(
-                  inputId = "selectArea",
-                  label = "Choose an area:",
-                  choices = choicesAreas$area_name
-                )
-              ),
-              column(
-                width = 12,
-                paste("Download the underlying data for this dashboard:"), br(),
-                downloadButton(
-                  outputId = "download_data",
-                  label = "Download data",
-                  icon = shiny::icon("download"),
-                  class = "downloadButton"
-                )
-              )
-            )
-          )
+          expandable(inputId = 'details', label = 'Expand me', help_text = 'Dropdowns here'),
+          # div(id = "div_a",
+          #   class = "well",
+          #   style = "min-height: 100%; height: 100%; overflow-y: visible",
+          #   gov_row(
+          #     column(
+          #       width = 6,
+          #       selectizeInput("selectPhase",
+          #         "Select a school phase",
+          #         choices = choicesPhase
+          #       )
+          #     ),
+          #     column(
+          #       width = 6,
+          #       selectizeInput(
+          #         inputId = "selectArea",
+          #         label = "Choose an area:",
+          #         choices = choicesAreas$area_name
+          #       )
+          #     ),
+          #     column(
+          #       width = 12,
+          #       paste("Download the underlying data for this dashboard:"), br(),
+          #       downloadButton(
+          #         outputId = "download_data",
+          #         label = "Download data",
+          #         icon = shiny::icon("download"),
+          #         class = "downloadButton"
+          #       )
+          #     )
+          #   )
+          # )
         ),
         column(
           width = 12,

--- a/global.R
+++ b/global.R
@@ -120,7 +120,7 @@ expandable <-function(inputId, label, contents){
   govDetails <- shiny::tags$details(class = "govuk-details", id = inputId,
                                     shiny::tags$summary(class = "govuk-details__summary",
                                                         shiny::tags$span(class = "govuk-details__summary-text",
-                                                                         shiny::HTML(label))
+                                                                         label)
                                     ),
                                     shiny::tags$div(contents)
   )

--- a/global.R
+++ b/global.R
@@ -116,40 +116,12 @@ choicesYears <- unique(dfRevBal$time_period)
 
 choicesPhase <- unique(dfRevBal$school_phase)
 
-expandable <-function(inputId, label, help_text){
+expandable <-function(inputId, label, contents){
   govDetails <- shiny::tags$details(class = "govuk-details", id = inputId,
                                     shiny::tags$summary(class = "govuk-details__summary",
                                                         shiny::tags$span(class = "govuk-details__summary-text",
                                                                          shiny::HTML(label))
                                     ),
-                                    shiny::tags$div(class = "well",
-                                                    style = "min-height: 100%; height: 100%; overflow-y: visible",
-                                                    gov_row(
-                                                      column(
-                                                        width = 6,
-                                                        selectizeInput("selectPhase",
-                                                                       "Select a school phase",
-                                                                       choices = choicesPhase
-                                                        )
-                                                      ),
-                                                      column(
-                                                        width = 6,
-                                                        selectizeInput(
-                                                          inputId = "selectArea",
-                                                          label = "Choose an area:",
-                                                          choices = choicesAreas$area_name
-                                                        )
-                                                      ),
-                                                      column(
-                                                        width = 12,
-                                                        paste("Download the underlying data for this dashboard:"), br(),
-                                                        downloadButton(
-                                                          outputId = "download_data",
-                                                          label = "Download data",
-                                                          icon = shiny::icon("download"),
-                                                          class = "downloadButton"
-                                                        )
-                                                      )
-                                                    ))
+                                    shiny::tags$div(contents)
   )
 }

--- a/global.R
+++ b/global.R
@@ -116,12 +116,16 @@ choicesYears <- unique(dfRevBal$time_period)
 
 choicesPhase <- unique(dfRevBal$school_phase)
 
-expandable <-function(inputId, label, contents){
-  govDetails <- shiny::tags$details(class = "govuk-details", id = inputId,
-                                    shiny::tags$summary(class = "govuk-details__summary",
-                                                        shiny::tags$span(class = "govuk-details__summary-text",
-                                                                         label)
-                                    ),
-                                    shiny::tags$div(contents)
+expandable <- function(inputId, label, contents) {
+  govDetails <- shiny::tags$details(
+    class = "govuk-details", id = inputId,
+    shiny::tags$summary(
+      class = "govuk-details__summary",
+      shiny::tags$span(
+        class = "govuk-details__summary-text",
+        label
+      )
+    ),
+    shiny::tags$div(contents)
   )
 }

--- a/global.R
+++ b/global.R
@@ -118,10 +118,10 @@ choicesPhase <- unique(dfRevBal$school_phase)
 
 expandable <-function(inputId, label, contents){
   govDetails <- shiny::tags$details(class = "govuk-details", id = inputId,
-                                    shiny::tags$summary(class = "well", style = "min-height: 100%; height: 100%; overflow-y: visible",
+                                    shiny::tags$summary(class = "govuk-details__summary",
                                                         shiny::tags$span(class = "govuk-details__summary-text",
                                                                          shiny::HTML(label))
                                     ),
-                                    shiny::tags$div(class = "well", style = "min-height: 100%; height: 100%; overflow-y: visible",contents)
+                                    shiny::tags$div(contents)
   )
 }

--- a/global.R
+++ b/global.R
@@ -118,10 +118,10 @@ choicesPhase <- unique(dfRevBal$school_phase)
 
 expandable <-function(inputId, label, contents){
   govDetails <- shiny::tags$details(class = "govuk-details", id = inputId,
-                                    shiny::tags$summary(class = "govuk-details__summary",
+                                    shiny::tags$summary(class = "well", style = "min-height: 100%; height: 100%; overflow-y: visible",
                                                         shiny::tags$span(class = "govuk-details__summary-text",
                                                                          shiny::HTML(label))
                                     ),
-                                    shiny::tags$div(contents)
+                                    shiny::tags$div(class = "well", style = "min-height: 100%; height: 100%; overflow-y: visible",contents)
   )
 }

--- a/global.R
+++ b/global.R
@@ -115,3 +115,41 @@ choicesAreas <- dfAreas %>%
 choicesYears <- unique(dfRevBal$time_period)
 
 choicesPhase <- unique(dfRevBal$school_phase)
+
+expandable <-function(inputId, label, help_text){
+  govDetails <- shiny::tags$details(class = "govuk-details", id = inputId,
+                                    shiny::tags$summary(class = "govuk-details__summary",
+                                                        shiny::tags$span(class = "govuk-details__summary-text",
+                                                                         shiny::HTML(label))
+                                    ),
+                                    shiny::tags$div(class = "well",
+                                                    style = "min-height: 100%; height: 100%; overflow-y: visible",
+                                                    gov_row(
+                                                      column(
+                                                        width = 6,
+                                                        selectizeInput("selectPhase",
+                                                                       "Select a school phase",
+                                                                       choices = choicesPhase
+                                                        )
+                                                      ),
+                                                      column(
+                                                        width = 6,
+                                                        selectizeInput(
+                                                          inputId = "selectArea",
+                                                          label = "Choose an area:",
+                                                          choices = choicesAreas$area_name
+                                                        )
+                                                      ),
+                                                      column(
+                                                        width = 12,
+                                                        paste("Download the underlying data for this dashboard:"), br(),
+                                                        downloadButton(
+                                                          outputId = "download_data",
+                                                          label = "Download data",
+                                                          icon = shiny::icon("download"),
+                                                          class = "downloadButton"
+                                                        )
+                                                      )
+                                                    ))
+  )
+}

--- a/server.R
+++ b/server.R
@@ -204,9 +204,10 @@ server <- function(input, output, session) {
       fontsize = "large"
     )
   })
-
-
-
+  
+  observeEvent(input$go,{
+    toggle(id = "div_a",anim = T)
+  })
 
 
   observeEvent(input$link_to_app_content_tab, {

--- a/server.R
+++ b/server.R
@@ -204,9 +204,9 @@ server <- function(input, output, session) {
       fontsize = "large"
     )
   })
-  
-  observeEvent(input$go,{
-    toggle(id = "div_a",anim = T)
+
+  observeEvent(input$go, {
+    toggle(id = "div_a", anim = T)
   })
 
 
@@ -221,9 +221,9 @@ server <- function(input, output, session) {
       write.csv(dfRevBal, file)
     }
   )
-  
+
   output$dropdown_label <- renderText({
-    paste("Current selections: ",input$selectPhase,",",input$selectArea)
+    paste("Current selections: ", input$selectPhase, ",", input$selectArea)
   })
 
 

--- a/server.R
+++ b/server.R
@@ -221,6 +221,10 @@ server <- function(input, output, session) {
       write.csv(dfRevBal, file)
     }
   )
+  
+  output$dropdown_label <- renderText({
+    paste("Current selections: ",input$selectPhase,",",input$selectArea)
+  })
 
 
   # Stop app ---------------------------------------------------------------------------------

--- a/ui.R
+++ b/ui.R
@@ -58,7 +58,7 @@
 
 ui <- function(input, output, session) {
   fluidPage(
-    #    use_tota11y(),
+    # use_tota11y(),
     title = tags$head(
       tags$link(
         rel = "shortcut icon",

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -136,6 +136,7 @@ a:active {
 }
 
 .govuk-details {
+    padding: 19px;
     font-family: GDS Transport, arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     background-color: #1d70b8;
@@ -143,6 +144,17 @@ a:active {
     color: #fff;
     margin-bottom: 20px;
     display: block;
+    border: 1px solid #e3e3e3;
+    border-radius: 4px;
+}
+
+.govuk-details__summary {
+    display: inline-block;
+    position: relative;
+    margin-bottom: 5px;
+    padding-left: 25px;
+    color: #fff;
+    cursor: pointer;
 }
 
 

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -135,6 +135,16 @@ a:active {
     color: #fff;
 }
 
+.govuk-details {
+    font-family: GDS Transport, arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    background-color: #1d70b8;
+    font-weight: 400;
+    color: #fff;
+    margin-bottom: 20px;
+    display: block;
+}
+
 
 /* Full screen plots */
 /* Adapted from https://stackoverflow.com/questions/69042546/is-there-a-way-to-create-a-full-screen-popup-window-of-a-plotly-chart-in-r */


### PR DESCRIPTION
## Pull request overview

Copy of #46 but into development first rather than straight to main. 
Make the dropdowns 'well' collapsible/expandable. 
I have used the code behind the details() function of the shinygovstyle package to develop the expandable title. 

## Pull request checklist

Please check if your PR fulfils the following:
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

Currently the template places dropdowns in a blue 'well' at the top of the page as seen below. This can get large if the dashboard uses lots of dropdowns and can dominate the page/take away from the results below. 
![image](https://user-images.githubusercontent.com/101197790/208480473-3a22687e-86c8-4c62-932a-5457257665e6.png)


## What is the new behaviour?

We have added the ability to collapse and expand this section, with a title that states the current selections. 
![image](https://user-images.githubusercontent.com/101197790/208480734-d1272264-e42b-4de1-8526-41778867d1f1.png)
which expands when clicked: 
![image](https://user-images.githubusercontent.com/101197790/208480794-fa57b897-0505-4df2-a94f-f8f7382e9535.png)


## Anything else

It is already the plan to restyle this, but I am merging the current functionality into development as suggested here: https://github.com/dfe-analytical-services/shiny-template/pull/46#issuecomment-1369293297
