### PR TITLE
Added dynamic window title using shinytitle

### DIFF
--- a/global.R
+++ b/global.R
@@ -18,6 +18,7 @@ shhh(library(shinytest))
 shhh(library(shinydashboard))
 shhh(library(shinyWidgets))
 shhh(library(shinyGovstyle))
+shhh(library(shinytitle))
 shhh(library(dplyr))
 shhh(library(ggplot2))
 shhh(library(plotly))
@@ -87,10 +88,11 @@ appLoadingCSS <- "
 }
 "
 
-site_primary <- "https://department-for-education.shinyapps.io/dfe-shiny-template/"
+site_title    <- "DfE Shiny Template" 
+site_primary  <- "https://department-for-education.shinyapps.io/dfe-shiny-template/"
 site_overflow <- "https://department-for-education.shinyapps.io/dfe-shiny-template-overflow/"
-sites_list <- c(site_primary, site_overflow) # We can add further mirrors where necessary. Each one can generally handle about 2,500 users simultaneously
-ees_pub_name <- "Statistical publication" # Update this with your parent publication name (e.g. the EES publication)
+sites_list    <- c(site_primary, site_overflow) # We can add further mirrors where necessary. Each one can generally handle about 2,500 users simultaneously
+ees_pub_name  <- "Statistical publication" # Update this with your parent publication name (e.g. the EES publication)
 ees_publication <- "https://explore-education-statistics.service.gov.uk/find-statistics/" # Update with parent publication link
 google_analytics_key <- "Z967JJVQQX"
 

--- a/global.R
+++ b/global.R
@@ -88,11 +88,11 @@ appLoadingCSS <- "
 }
 "
 
-site_title    <- "DfE Shiny Template" 
-site_primary  <- "https://department-for-education.shinyapps.io/dfe-shiny-template/"
+site_title <- "DfE Shiny Template"
+site_primary <- "https://department-for-education.shinyapps.io/dfe-shiny-template/"
 site_overflow <- "https://department-for-education.shinyapps.io/dfe-shiny-template-overflow/"
-sites_list    <- c(site_primary, site_overflow) # We can add further mirrors where necessary. Each one can generally handle about 2,500 users simultaneously
-ees_pub_name  <- "Statistical publication" # Update this with your parent publication name (e.g. the EES publication)
+sites_list <- c(site_primary, site_overflow) # We can add further mirrors where necessary. Each one can generally handle about 2,500 users simultaneously
+ees_pub_name <- "Statistical publication" # Update this with your parent publication name (e.g. the EES publication)
 ees_publication <- "https://explore-education-statistics.service.gov.uk/find-statistics/" # Update with parent publication link
 google_analytics_key <- "Z967JJVQQX"
 

--- a/renv.lock
+++ b/renv.lock
@@ -1041,6 +1041,16 @@
         "withr"
       ]
     },
+    "shinytitle": {
+      "Package": "shinytitle",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "12a2972d88910692c1a125d6e1e95d51",
+      "Requirements": [
+        "shiny"
+      ]
+    },
     "showimage": {
       "Package": "showimage",
       "Version": "1.0.0",

--- a/server.R
+++ b/server.R
@@ -35,9 +35,27 @@ server <- function(input, output, session) {
     reactiveValuesToList(input)
     session$doBookmark()
   })
+  
   onBookmarked(function(url) {
     updateQueryString(url)
   })
+  
+  observe({
+    if(input$navlistPanel=='dashboard'){
+    change_window_title(
+      session, 
+      paste0(
+        site_title, ' - ', 
+        input$selectPhase, ', ',
+        input$selectArea))
+    } else {
+      change_window_title(
+        session, 
+        paste0(
+          site_title, ' - ', 
+          input$navlistPanel))
+    }
+    })
 
   # output if cookie is unspecified
   observeEvent(input$cookies, {

--- a/server.R
+++ b/server.R
@@ -35,27 +35,31 @@ server <- function(input, output, session) {
     reactiveValuesToList(input)
     session$doBookmark()
   })
-  
+
   onBookmarked(function(url) {
     updateQueryString(url)
   })
-  
+
   observe({
-    if(input$navlistPanel=='dashboard'){
-    change_window_title(
-      session, 
-      paste0(
-        site_title, ' - ', 
-        input$selectPhase, ', ',
-        input$selectArea))
+    if (input$navlistPanel == "dashboard") {
+      change_window_title(
+        session,
+        paste0(
+          site_title, " - ",
+          input$selectPhase, ", ",
+          input$selectArea
+        )
+      )
     } else {
       change_window_title(
-        session, 
+        session,
         paste0(
-          site_title, ' - ', 
-          input$navlistPanel))
+          site_title, " - ",
+          input$navlistPanel
+        )
+      )
     }
-    })
+  })
 
   # output if cookie is unspecified
   observeEvent(input$cookies, {

--- a/ui.R
+++ b/ui.R
@@ -67,6 +67,7 @@ ui <- function(input, output, session) {
       # Add title for browser tabs
       tags$title("DfE Shiny Template")
     ),
+    use_shiny_title(),
     tags$html(lang = "en"),
     # Add meta description for search engines
     meta() %>%


### PR DESCRIPTION
Nice and simple solution for updating the window title using shinytitle package. Have done a demo version that lists the App name and page if the user isn't on the main dashboard panel and lists the App name and a couple of inputs if they are.

Support and feedback example
![image](https://user-images.githubusercontent.com/230859/235925439-f4647b53-ff3e-4b08-be69-12c8cc238ee0.png)

Dashboard page with inputs example
![image](https://user-images.githubusercontent.com/230859/235925307-a518f52b-5bb9-4f3e-94a5-eb0757ef671d.png)
