### PR TITLE
Adding afcolours package

### DIFF
--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -171,7 +171,7 @@ dashboard_panel <- function() {
                         column(
                           width = 12,
                           selectizeInput("selectBenchLAs",
-                            "Select benchamrk LAs",
+                            "Select benchmark LAs",
                             choices = choicesLAs$area_name,
                             multiple = TRUE,
                             options = list(maxItems = 3)

--- a/R/dfe_resources.R
+++ b/R/dfe_resources.R
@@ -4,4 +4,7 @@
 # Note the advice on trying to keep to a maximum of 4 series in a single plot
 # (the two commented out hex codes are for the suggested colours for two
 # additional series if absolutely necessary).
-gss_colour_pallette <- c("#12436D", "#28A197", "#801650", "#F46A25", "#3D3D3D", "#A285D1")
+# 2023-09-21: update made to change hex codes to AF colours package
+# guidance here: https://best-practice-and-impact.github.io/afcolours/ 
+
+gss_colour_pallette <- afcolours::af_colours("categorical", colour_format = "hex", n = 6)

--- a/R/dfe_resources.R
+++ b/R/dfe_resources.R
@@ -5,6 +5,6 @@
 # (the two commented out hex codes are for the suggested colours for two
 # additional series if absolutely necessary).
 # 2023-09-21: update made to change hex codes to AF colours package
-# guidance here: https://best-practice-and-impact.github.io/afcolours/ 
+# guidance here: https://best-practice-and-impact.github.io/afcolours/
 
 gss_colour_pallette <- afcolours::af_colours("categorical", colour_format = "hex", n = 6)

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -12,7 +12,7 @@ gtag('consent', 'default', {
 </script>
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Z967JJVQQX"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
@@ -22,7 +22,7 @@ gtag('consent', 'default', {
 /*
 The tracking number below MUST be replaced with a unique number, contact the statistics development team to set this up. 
 */
-  gtag('config', 'G-Z967JJVQQX');
+  gtag('config', 'G-XXXXXXXXXX');
   
 
   $(document).on('change', 'select#selectPhase', function(e) {

--- a/renv.lock
+++ b/renv.lock
@@ -25,20 +25,19 @@
     },
     "DT": {
       "Package": "DT",
-      "Version": "0.29",
+      "Version": "0.28",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "crosstalk",
         "htmltools",
         "htmlwidgets",
-        "httpuv",
         "jquerylib",
         "jsonlite",
         "magrittr",
         "promises"
       ],
-      "Hash": "02f42b77a951a5ea7c891ef5c187d774"
+      "Hash": "ab745834dfae7eaf71dd0b90f3b66759"
     },
     "MASS": {
       "Package": "MASS",
@@ -57,7 +56,7 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.6-1",
+      "Version": "1.6-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -70,7 +69,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "cb6855ac711958ca734b75e631b2035d"
+      "Hash": "31262fd18481fab05c5e7258dac163ca"
     },
     "R.cache": {
       "Package": "R.cache",
@@ -171,13 +170,13 @@
     },
     "askpass": {
       "Package": "askpass",
-      "Version": "1.2.0",
+      "Version": "1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "sys"
       ],
-      "Hash": "cad6cf7f1d5f6e906700b9d3e718c796"
+      "Hash": "e8a22846fff485f0be3770c2da758713"
     },
     "backports": {
       "Package": "backports",
@@ -208,7 +207,7 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.5.1",
+      "Version": "0.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -224,7 +223,7 @@
         "rlang",
         "sass"
       ],
-      "Hash": "283015ddfbb9d7bf15ea9f0b5698f0d9"
+      "Hash": "1b117970533deb6d4e992c1b34e9d905"
     },
     "cachem": {
       "Package": "cachem",
@@ -360,13 +359,13 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "5.0.2",
+      "Version": "5.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "511bacbfa153a15251166b463b4da4f9"
+      "Hash": "2118af9cb164c8d2dddc7b89eaf732d9"
     },
     "data.table": {
       "Package": "data.table",
@@ -421,7 +420,7 @@
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.1.3",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -440,7 +439,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "e85ffbebaad5f70e1a2e2ef4302b4949"
+      "Hash": "dea6970ff715ca541c387de363ff405e"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -492,7 +491,7 @@
     },
     "fontawesome": {
       "Package": "fontawesome",
-      "Version": "0.5.2",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -500,7 +499,7 @@
         "htmltools",
         "rlang"
       ],
-      "Hash": "c2efdd5f0bcd1ea861c2d4e2a883a67d"
+      "Hash": "1e22b8cabbad1eae951a75e9f8b52378"
     },
     "fs": {
       "Package": "fs",
@@ -526,7 +525,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.4.3",
+      "Version": "3.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -547,7 +546,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "85846544c596e71f8f46483ab165da33"
+      "Hash": "3a147ee02e85a8941aad9909f1b43b7b"
     },
     "globals": {
       "Package": "globals",
@@ -573,7 +572,7 @@
     },
     "gtable": {
       "Package": "gtable",
-      "Version": "0.3.4",
+      "Version": "0.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -584,7 +583,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "b29cf3031f49b04ab9c852c912547eef"
+      "Hash": "b44addadb528a0d227794121c00572a0"
     },
     "highr": {
       "Package": "highr",
@@ -599,7 +598,7 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.6",
+      "Version": "0.5.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -612,7 +611,7 @@
         "rlang",
         "utils"
       ],
-      "Hash": "a2326a66919a3311f7fbb1e3bf568283"
+      "Hash": "ba0240784ad50a62165058a27459304a"
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
@@ -646,7 +645,7 @@
     },
     "httr": {
       "Package": "httr",
-      "Version": "1.4.7",
+      "Version": "1.4.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -657,7 +656,7 @@
         "mime",
         "openssl"
       ],
-      "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
+      "Hash": "7e5e3cbd2a7bc07880c94e22348fb661"
     },
     "isoband": {
       "Package": "isoband",
@@ -692,7 +691,7 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.44",
+      "Version": "1.43",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -704,18 +703,18 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "60885b9f746c9dfaef110d070b5f7dc0"
+      "Hash": "9775eb076713f627c07ce41d8199d8f6"
     },
     "labeling": {
       "Package": "labeling",
-      "Version": "0.4.3",
+      "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "graphics",
         "stats"
       ],
-      "Hash": "b64ec208ac5bc1852b285f665d6368b3"
+      "Hash": "3d5108641f47470611a32d0bdf357a72"
     },
     "later": {
       "Package": "later",
@@ -974,19 +973,18 @@
     },
     "promises": {
       "Package": "promises",
-      "Version": "1.2.1",
+      "Version": "1.2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R6",
         "Rcpp",
-        "fastmap",
         "later",
         "magrittr",
         "rlang",
         "stats"
       ],
-      "Hash": "0d8a15c9d000970ada1ab21405387dee"
+      "Hash": "4ab2c43adb4d4699cf3690acd378d75d"
     },
     "ps": {
       "Package": "ps",
@@ -1036,13 +1034,13 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.2",
+      "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "4b22ac016fe54028b88d0c68badbd061"
+      "Hash": "c321cd99d56443dbffd1c9e673c0c1a2"
     },
     "rlang": {
       "Package": "rlang",
@@ -1057,7 +1055,7 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.24",
+      "Version": "2.23",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1077,7 +1075,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "3854c37590717c08c32ec8542a2e0a35"
+      "Hash": "79f14e53725f28900d936f692bfdd69f"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -1178,7 +1176,7 @@
     },
     "shinyWidgets": {
       "Package": "shinyWidgets",
-      "Version": "0.8.0",
+      "Version": "0.7.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1192,7 +1190,7 @@
         "sass",
         "shiny"
       ],
-      "Hash": "c6acc72327e63668bbc7bd258ee54132"
+      "Hash": "fd889b32caa37b8ed9b1e9e7ef1564bc"
     },
     "shinyalert": {
       "Package": "shinyalert",
@@ -1314,7 +1312,7 @@
     },
     "styler": {
       "Package": "styler",
-      "Version": "1.10.2",
+      "Version": "1.10.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1329,7 +1327,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "d61238fd44fc63c8adf4565efe8eb682"
+      "Hash": "b0911fdb2c682f526f6e9c131fd40a1f"
     },
     "sys": {
       "Package": "sys",
@@ -1448,13 +1446,13 @@
     },
     "uuid": {
       "Package": "uuid",
-      "Version": "1.1-1",
+      "Version": "1.1-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "3d78edfb977a69fc7a0341bee25e163f"
+      "Hash": "f1cb46c157d080b729159d407be83496"
     },
     "vctrs": {
       "Package": "vctrs",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,26 +2,11 @@
 local({
 
   # the requested version of renv
-  version <- "1.0.2"
+  version <- "1.0.0"
   attr(version, "sha") <- NULL
 
   # the project directory
   project <- getwd()
-
-  # use start-up diagnostics if enabled
-  diagnostics <- Sys.getenv("RENV_STARTUP_DIAGNOSTICS", unset = "FALSE")
-  if (diagnostics) {
-    start <- Sys.time()
-    profile <- tempfile("renv-startup-", fileext = ".Rprof")
-    utils::Rprof(profile)
-    on.exit({
-      utils::Rprof(NULL)
-      elapsed <- signif(difftime(Sys.time(), start, units = "auto"), digits = 2L)
-      writeLines(sprintf("- renv took %s to run the autoloader.", format(elapsed)))
-      writeLines(sprintf("- Profile: %s", profile))
-      print(utils::summaryRprof(profile))
-    }, add = TRUE)
-  }
 
   # figure out whether the autoloader is enabled
   enabled <- local({
@@ -519,7 +504,7 @@ local({
   
     # open the bundle for reading
     # We use gzcon for everything because (from ?gzcon)
-    # > Reading from a connection which does not supply a 'gzip' magic
+    # > Reading from a connection which does not supply a ‘gzip’ magic
     # > header is equivalent to reading from the original connection
     conn <- gzcon(file(bundle, open = "rb", raw = TRUE))
     on.exit(close(conn))
@@ -782,12 +767,10 @@ local({
   renv_bootstrap_validate_version <- function(version, description = NULL) {
   
     # resolve description file
-    #
-    # avoid passing lib.loc to `packageDescription()` below, since R will
-    # use the loaded version of the package by default anyhow. note that
-    # this function should only be called after 'renv' is loaded
-    # https://github.com/rstudio/renv/issues/1625
-    description <- description %||% packageDescription("renv")
+    description <- description %||% {
+      path <- getNamespaceInfo("renv", "path")
+      packageDescription("renv", lib.loc = dirname(path))
+    }
   
     # check whether requested version 'version' matches loaded version of renv
     sha <- attr(version, "sha", exact = TRUE)
@@ -858,7 +841,7 @@ local({
     hooks <- getHook("renv::autoload")
     for (hook in hooks)
       if (is.function(hook))
-        tryCatch(hook(), error = warnify)
+        tryCatch(hook(), error = warning)
   
     # load the project
     renv::load(project)
@@ -999,15 +982,10 @@ local({
   
   }
   
-  renv_bootstrap_version_friendly <- function(version, shafmt = NULL, sha = NULL) {
+  renv_bootstrap_version_friendly <- function(version, sha = NULL) {
     sha <- sha %||% attr(version, "sha", exact = TRUE)
-    parts <- c(version, sprintf(shafmt %||% " [sha: %s]", substring(sha, 1L, 7L)))
-    paste(parts, collapse = "")
-  }
-  
-  renv_bootstrap_exec <- function(project, libpath, version) {
-    if (!renv_bootstrap_load(project, libpath, version))
-      renv_bootstrap_run(version, libpath)
+    parts <- c(version, sprintf("[sha: %s]", substring(sha, 1L, 7L)))
+    paste(parts, collapse = " ")
   }
   
   renv_bootstrap_run <- function(version, libpath) {
@@ -1037,14 +1015,6 @@ local({
   
   renv_bootstrap_in_rstudio <- function() {
     commandArgs()[[1]] == "RStudio"
-  }
-  
-  # Used to work around buglet in RStudio if hook uses readline
-  renv_bootstrap_flush_console <- function() {
-    tryCatch({
-      tools <- as.environment("tools:rstudio")
-      tools$.rs.api.sendToConsole("", echo = FALSE, focus = FALSE)
-    }, error = function(cnd) {})
   }
   
   renv_json_read <- function(file = NULL, text = NULL) {
@@ -1185,15 +1155,25 @@ local({
   # construct full libpath
   libpath <- file.path(root, prefix)
 
+  # attempt to load
+  if (renv_bootstrap_load(project, libpath, version))
+    return(TRUE)
+
   if (renv_bootstrap_in_rstudio()) {
-    # RStudio only updates console once .Rprofile is finished, so
-    # instead run code on sessionInit
     setHook("rstudio.sessionInit", function(...) {
-      renv_bootstrap_exec(project, libpath, version)
-      renv_bootstrap_flush_console()
+      renv_bootstrap_run(version, libpath)
+
+      # Work around buglet in RStudio if hook uses readline
+      tryCatch(
+        {
+          tools <- as.environment("tools:rstudio")
+          tools$.rs.api.sendToConsole("", echo = FALSE, focus = FALSE)
+        },
+        error = function(cnd) {}
+      )
     })
   } else {
-    renv_bootstrap_exec(project, libpath, version)
+    renv_bootstrap_run(version, libpath)
   }
 
   invisible()


### PR DESCRIPTION
## Pull request overview

- afcolours package added to renv (documentation here: [https://best-practice-and-impact.github.io/afcolours/](https://best-practice-and-impact.github.io/afcolours/)
- `dfe_resources` code updated to point to afcolours package rather than manually input hex codes
- typo fixed on line 174 of `dashboard_panels` code
- `tidy_code` run
- checked that the app runs and the colours look correct

Can someone just sense check what I've done please? Thanks! 
