### PR TITLE
Change the way dfeshiny snapshot to git rather than github

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.1",
+    "Version": "4.3.2",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -397,19 +397,16 @@
     "dfeshiny": {
       "Package": "dfeshiny",
       "Version": "0.1.1",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteUsername": "dfe-analytical-services",
-      "RemoteRepo": "dfeshiny",
-      "RemoteRef": "main",
-      "RemoteSha": "d90d2099892d1ff0f4c688213952f9512d9dea16",
-      "RemoteHost": "api.github.com",
+      "Source": "git",
+      "RemoteType": "git",
+      "RemoteUrl": "https://github.com/dfe-analytical-services/dfeshiny",
+      "RemoteRef": "",
       "Requirements": [
         "shiny",
         "shinyGovstyle",
         "styler"
       ],
-      "Hash": "cd664e1910e9b52deaddcf1b92aeabda"
+      "Hash": "18ef87ef6400ddf97ba458852ba7442c"
     },
     "diffobj": {
       "Package": "diffobj",


### PR DESCRIPTION
## Pull request overview

Previously I was unable to restore the dfeshiny package. It also wouldn't work by doing `renv::install("dfe-analytical-services/dfeshiny")` either.

Installing using `renv::install("git::https://github.com/dfe-analytical-services/dfeshiny")` did however work.

I noticed then, that if I restored everything else using `renv::restore(exclude = "dfeshiny)`, and then used `renv::status()` there was a difference in the way it had been installed (I don't understand it, I can just see it's showing different):

![image](https://github.com/dfe-analytical-services/shiny-template/assets/52536248/613dc75c-a6f5-48c3-8f20-bb34949331ce)

## Pull request checklist

Please check if your PR fulfils the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

It used to produce this error

![image](https://github.com/dfe-analytical-services/shiny-template/assets/52536248/4c61eb82-336a-4fe7-9d6d-9a06b7beffd5)

It also used to seem to be saved as 'dfe-analytical-services/dfeshiny@main' (lockfile)

![image](https://github.com/dfe-analytical-services/shiny-template/assets/52536248/520d55cf-40e4-444c-92ec-3b38703da494)

## What is the new behaviour?

It now installs / restores without issue.

It seems to now be storing as a version number instead (currently 0.1.1 and showing in my library)

![image](https://github.com/dfe-analytical-services/shiny-template/assets/52536248/13c38264-624e-478a-827b-31651bc92021)

## Anything else

Might be worth deleting the repo and recloning to test this on this branch against main to see if it works.

The R version has also updated, as all the tests were passing I've just left this in assuming it's fine, happy to roll that back if it causes issues I've missed though.
