### PR TITLE
Changing accessibility statement to replicate the one on EES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .RData
 .RData*
 .Ruserdata
+*_.new.png
 *unpublished*

--- a/.hooks/pre-commit.R
+++ b/.hooks/pre-commit.R
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-cat("Running commit hooks...",fill=TRUE)
+cat("Running commit hooks...", fill = TRUE)
 shhh <- suppressPackageStartupMessages # It's a library, so shhh!
 shhh(library(dplyr))
 shhh(library(xfun))
@@ -16,12 +16,12 @@ cat("Contents of the .gitignore file:")
 print(ign_files)
 
 # Run a pass through the .gitignore files and look for any issues
-if(ncol(ign_files)>1){
+if (ncol(ign_files) > 1) {
   cat("ERROR: It looks like you've got commas in the .gitignore. Please correct the .gitignore file and try again.")
   error_flag <- TRUE
 } else {
-  for(i in 1:nrow(ign_files)){
-    if(grepl(' ',ign_files$filename[i])){
+  for (i in 1:nrow(ign_files)) {
+    if (grepl(" ", ign_files$filename[i])) {
       cat("ERROR: It looks like you've got spaces in filenames in the .gitignore. Please rename your files if they contain spaces and update the .gitignore file accordingly.")
       error_flag <- TRUE
     }
@@ -41,25 +41,24 @@ for (file in current_files$files) {
   } else {
     file_status <- (log_files %>% filter(filename == file))$status
     if (!file_status %in% c("published", "Published", "reference", "Reference", "dummy", "Dummy")) {
-      if (!file %in% ign_files$filename & !grepl("unpublished",file)) {
+      if (!file %in% ign_files$filename & !grepl("unpublished", file)) {
         cat("Error:", file, "is not logged as published or reference data in datafiles_log.csv and is not found in .gitignore.\n\n")
         cat("If the file contains published or reference data then update its entry in datafiles_log.csv.\n\n")
         cat("If the file contains unpublished data then add it to the .gitignore file.\n\n")
         error_flag <- TRUE
-      }
-      else {
-        cat(file,"is recorded in the logfile as unpublished data and in .gitignore and so will not be included as part of the commit.\n\n")
+      } else {
+        cat(file, "is recorded in the logfile as unpublished data and in .gitignore and so will not be included as part of the commit.\n\n")
       }
     }
   }
 }
 
-if(grepl('G-Z967JJVQQX', htmltools::includeHTML(("google-analytics.html"))) & 
-   !(toupper(Sys.getenv("USERNAME")) %in% c("CFOSTER4", "CRACE", "LSELBY","RBIELBY", "JMACHIN"))){
-  cat("Cleaning out the template's Google Analytics tag.",fill=TRUE)
+if (grepl("G-Z967JJVQQX", htmltools::includeHTML(("google-analytics.html"))) &
+  !(toupper(Sys.getenv("USERNAME")) %in% c("CFOSTER4", "CRACE", "LSELBY", "RBIELBY", "JMACHIN"))) {
+  cat("Cleaning out the template's Google Analytics tag.", fill = TRUE)
   gsub_file("google-analytics.html", pattern = "G-Z967JJVQQX", replacement = "G-XXXXXXXXXX")
   gsub_file("ui.R", pattern = "Z967JJVQQX", replacement = "XXXXXXXXXX")
-  system2(command = "git", args=c("add","google-analytics.html"))
+  system2(command = "git", args = c("add", "google-analytics.html"))
 }
 
 if (error_flag) {
@@ -68,7 +67,7 @@ if (error_flag) {
 }
 
 tidy_output <- tidy_code()
-if(any(tidy_output)){
+if (any(tidy_output)) {
   error_flag <- TRUE
 }
 

--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,4 @@
 linters:  linters_with_defaults(
-    object_usage_linter = NULL
+    object_usage_linter = NULL,
+    line_length_linter = line_length_linter(120L)
   )

--- a/R/standard_panels.R
+++ b/R/standard_panels.R
@@ -6,57 +6,56 @@ a11y_panel <- function() {
         column(
           width = 12,
           h1("Accessibility statement"),
-          br("This accessibility statement applies to the **application name**.
-            This application is run by the Department for Education. We want as
-            many people as possible to be able to use this application, and have
-            actively developed this application with accessibilty in mind."),
-          h2("WCAG 2.1 compliance"),
-          br(
-            "We follow the reccomendations of the ",
-            a(
-              href = "https://www.w3.org/TR/WCAG21/",
-              "WCAG 2.1 requirements. ",
-              onclick = "ga('send', 'event', 'click', 'link', 'IKnow', 1)"
-            ),
-            "This application has been checked using the ",
-            a(href = "https://github.com/ewenme/shinya11y", "Shinya11y tool "),
-            ", which did not detect accessibility issues.
-            This application also fully passes the accessibility audits checked
-            by the ",
-            a(
-              href = "https://developers.google.com/web/tools/lighthouse",
-              "Google Developer Lighthouse tool"
-            ),
-            ". This means that this application:"
-          ),
+          br("This website is run by the", a(href = "https://www.gov.uk/government/organisations/department-for-education", "Department for Education (DfE).", ""), 
+             "We want as many people as possible to be able to use this website. 
+             For example, that means you should be able to:"),
           tags$div(tags$ul(
-            tags$li("uses colours that have sufficient contrast"),
-            tags$li("allows you to zoom in up to 300% without the text spilling
-                    off the screen"),
-            tags$li("has its performance regularly monitored, with a team
-                    working on any feedback to improve accessibility for all
-                    users")
+            tags$li("change colours, contrast levels and fonts"),
+            tags$li("zoom in up to 300% without the text spilling off the screen"),
+            tags$li("navigate most of the website using just a keyboard"),
+            tags$li("navigate most of the website using speech recognition software"),
+            tags$li("listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)")
           )),
-          h2("Limitations"),
-          br("We recognise that there are still potential issues with
-          accessibility in this application, but we will continue to review
-          updates to technology available to us to keep improving accessibility
-          for all of our users. For example, these are known issues that we will
-          continue to monitor and improve:"),
+          br("We’ve also made the website text as simple as possible to understand."),
+          br(a(href = "https://mcmw.abilitynet.org.uk/", "AbilityNet", ""), " has advice on making your device easier to use if you have a disability."),
+          h2("How accessible this website is"),
+          br("We know some parts of this website are not fully accessible:"),
           tags$div(tags$ul(
-            tags$li("List"),
-            tags$li("known"),
-            tags$li("limitations, e.g."),
-            tags$li("Alternative text in interactive charts is limited to titles
-                    and could be more descriptive (although this data is
-                    available in csv format)")
+            tags$li("list them here")
           )),
-          h2("Feedback"),
-          br(
-            "If you have any feedback on how we could further improve the
-            accessibility of this application, please contact us at",
-            a(href = "mailto:email@education.gov.uk", "email@education.gov.uk")
-          )
+          h2("What to do if you cannot access parts of this website"),
+          br("If you need information on this website in a different format like accessible PDF, 
+             large print, easy read, audio recording or braille, email"), 
+          br((a(href="mailto:explore.statistics@education.gov.uk", "explore.statistics@education.gov.uk", ""))),
+          h2("Reporting accessibility problems with this website"),
+          br("We’re always looking to improve the accessibility of this website. 
+             If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact us:"),
+          br((a(href="mailto:explore.statistics@education.gov.uk", "explore.statistics@education.gov.uk", ""))),
+          h2("Technical information about this website's accessibility"),
+          br("The Department for Education (DfE) is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) 
+              (No. 2) Accessibility Regulations 2018.
+              This website is partially compliant with the", a(href = "https://www.w3.org/TR/WCAG21/", "Web Content Accessibility Guidelines version 2.1 AA standard", ""),
+             " due to the non-compliances listed below."),
+          h2("Non accessible content"),
+          br("The content listed below is non-accessible for the following reasons. 
+             We will address these issues to ensure our content is accessible."),
+          tags$div(tags$ul(
+            tags$li("list them here")
+          )),
+          h2("How we tested this website"),
+          br("This website was last tested on 27 September 2022 against", a(href = "https://www.w3.org/TR/WCAG21/", "Accessibility Guidelines WCAG2.1.", ""), 
+              "The test was carried out by the", a(href="https://digitalaccessibilitycentre.org/", "Digital accessibility centre (DAC).", ""),
+              "DAC tested a sample of pages to cover the core functionality of the service including:"),
+          tags$div(tags$ul(
+            tags$li("list them here")
+          )),
+          h2("What we're doing to improve accessibility"),
+          br("We plan to continually test the service for accessibility issues. Our current list of issues to be resolved is:"),
+          tags$div(tags$ul(
+            tags$li("list of github issues here")
+          )),
+          h2("Preparation of this accessibility statement"),
+          br("This statement was prepared on 1st July 2024. It was last reviewed on 1st July 2024.")
         )
       )
     )

--- a/R/standard_panels.R
+++ b/R/standard_panels.R
@@ -5,63 +5,160 @@ a11y_panel <- function() {
       gov_row(
         column(
           width = 12,
-          h1("Accessibility statement"),
+          h1("Accessibility statement for [service name]"), # TODO
           br(
-            "This website is run by the", a(href = "https://www.gov.uk/government/organisations/department-for-education", "Department for Education (DfE).", ""),
-            "We want as many people as possible to be able to use this website.
-             For example, that means you should be able to:"
+            "This accessibility statement applies to the [raw service URL] website. This website is run by the", # TODO
+            a(
+              href = "https://www.gov.uk/government/organisations/department-for-education",
+              "Department for Education (DfE)",
+              .noWS = "after"
+            ), ".",
+            "This statement does not cover any other services run by the Department for Education (DfE) or GOV.UK."
+          ),
+          h2("How you should be able to use this website"),
+          br(
+            "We want as many people as possible to be able to use this website. You should be able to:"
           ),
           tags$div(tags$ul(
-            tags$li("change colours, contrast levels and fonts"),
-            tags$li("zoom in up to 300% without the text spilling off the screen"),
-            tags$li("navigate most of the website using just a keyboard"),
-            tags$li("navigate most of the website using speech recognition software"),
-            tags$li("listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)")
+            tags$li("change colours, contrast levels and fonts using browser or device settings"),
+            tags$li("zoom in up to 400% without the text spilling off the screen"),
+            tags$li("navigate most of the website using a keyboard or speech recognition software"),
+            tags$li("listen to most of the website using a screen reader
+                    (including the most recent versions of JAWS, NVDA and VoiceOver)")
           )),
           br("We’ve also made the website text as simple as possible to understand."),
-          br(a(href = "https://mcmw.abilitynet.org.uk/", "AbilityNet", ""), " has advice on making your device easier to use if you have a disability."),
+          br(
+            a(
+              href = "https://mcmw.abilitynet.org.uk/",
+              "AbilityNet"
+            ),
+            " has advice on making your device easier to use if you have a disability."
+          ),
           h2("How accessible this website is"),
           br("We know some parts of this website are not fully accessible:"),
           tags$div(tags$ul(
-            tags$li("list them here")
+            tags$li("list them here") # TODO
           )),
-          h2("What to do if you cannot access parts of this website"),
-          br("If you need information on this website in a different format like accessible PDF,
-             large print, easy read, audio recording or braille, email"),
-          br((a(href = "mailto:explore.statistics@education.gov.uk", "explore.statistics@education.gov.uk", ""))),
-          h2("Reporting accessibility problems with this website"),
+          h2("Feedback and contact information"),
+          br(
+            "If you need information on this website in a different format please see the ",
+            a(
+              href = "", # TODO
+              "[source publication] on Explore education statistics", # TODO
+              .noWS = "after"
+            ),
+            ". More details are available on that service for alternative formats of this data.",
+          ),
           br("We’re always looking to improve the accessibility of this website.
-             If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact us:"),
-          br((a(href = "mailto:explore.statistics@education.gov.uk", "explore.statistics@education.gov.uk", ""))),
+             If you find any problems not listed on this page or think we’re not meeting
+             accessibility requirements, contact us:"),
+          tags$ul(tags$li(
+            a(
+              href = "mailto:explore.statistics@education.gov.uk",
+              "explore.statistics@education.gov.uk"
+            )
+          )),
+          h2("Enforcement procedure"),
+          br("The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies
+             (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+             (the ‘accessibility regulations’)."),
+          br(
+            "If you are not happy with how we respond to your complaint, ",
+            a(
+              href = "https://www.equalityadvisoryservice.com/",
+              "contact the Equality Advisory and Support Service (EASS)",
+              .noWS = "after"
+            ),
+            "."
+          ),
           h2("Technical information about this website's accessibility"),
           br(
-            "The Department for Education (DfE) is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications)
-              (No. 2) Accessibility Regulations 2018.
-              This website is partially compliant with the", a(href = "https://www.w3.org/TR/WCAG21/", "Web Content Accessibility Guidelines version 2.1 AA standard", ""),
+            "The Department for Education (DfE) is committed to making its website accessible,
+            in accordance with the Public Sector Bodies (Websites and Mobile Applications)
+              (No. 2) Accessibility Regulations 2018."
+          ),
+          h3("Compliance status"),
+          br(
+            "This website is partially compliant with the", # TODO
+            a(
+              href = "https://www.w3.org/TR/WCAG21/",
+              "Web Content Accessibility Guidelines version 2.1 AA standard",
+              .noWS = "after"
+            ),
             " due to the non-compliances listed below."
           ),
-          h2("Non accessible content"),
+          h3("Non accessible content"),
           br("The content listed below is non-accessible for the following reasons.
              We will address these issues to ensure our content is accessible."),
           tags$div(tags$ul(
-            tags$li("list them here")
+            tags$li("list them here") # TODO
           )),
+          h3("Disproportionate burden"),
+          br("Not applicable."),
           h2("How we tested this website"),
           br(
-            "This website was last tested on 27 September 2022 against", a(href = "https://www.w3.org/TR/WCAG21/", "Accessibility Guidelines WCAG2.1.", ""),
-            "The test was carried out by the", a(href = "https://digitalaccessibilitycentre.org/", "Digital accessibility centre (DAC).", ""),
-            "DAC tested a sample of pages to cover the core functionality of the service including:"
+            "The template used for this website was last tested on 12 March 2024 against",
+            a(
+              href = "https://www.w3.org/TR/WCAG22/",
+              "Accessibility Guidelines WCAG2.2",
+              .noWS = "after"
+            ),
+            ". The test was carried out by the",
+            a(
+              href = "https://digitalaccessibilitycentre.org/",
+              "Digital accessibility centre (DAC)",
+              .noWS = "after"
+            ),
+            "."
           ),
+          br("DAC tested a sample of pages to cover the core functionality of the service including:"),
           tags$div(tags$ul(
-            tags$li("list them here")
+            tags$li("navigation"),
+            tags$li("interactive dropdown selections"),
+            tags$li("charts, maps, and tables")
           )),
+          br(
+            "This specific website was was last tested on [date] against", # TODO
+            a(
+              href = "https://www.w3.org/TR/WCAG22/",
+              "Accessibility Guidelines WCAG2.2",
+              .noWS = "after"
+            ),
+            ". The test was carried out by the",
+            a(
+              href = "https://www.gov.uk/government/organisations/department-for-education",
+              "Department for Education (DfE)",
+              .noWS = "after"
+            ),
+            "."
+          ),
           h2("What we're doing to improve accessibility"),
-          br("We plan to continually test the service for accessibility issues. Our current list of issues to be resolved is:"),
-          tags$div(tags$ul(
-            tags$li("list of github issues here")
-          )),
+          br(
+            "We plan to continually test the service for accessibility issues, and are working through a prioritised
+          list of issues to resolve."
+          ),
+          br(
+            "Our current list of issues to be resolved is available on our ",
+            a(
+              href = "", # TODO
+              "[GitHub issues page]", # TODO
+              .noWS = "after"
+            ),
+            "."
+          ),
           h2("Preparation of this accessibility statement"),
-          br("This statement was prepared on 1st July 2024. It was last reviewed on 1st July 2024.")
+          br("This statement was prepared on 1st July 2024. It was last reviewed on [date]."), # TODO
+          br(
+            "The template used for this website was last testing in March 2024 against the WCAG 2.2 AA standard.
+          This test of a representative sample of pages was carried out by the",
+            a(
+              href = "https://digitalaccessibilitycentre.org/",
+              "Digital accessibility centre (DAC)",
+              .noWS = "after"
+            ),
+            "."
+          ),
+          br("We also used findings from our own testing when preparing this accessibility statement.")
         )
       )
     )

--- a/R/standard_panels.R
+++ b/R/standard_panels.R
@@ -6,9 +6,11 @@ a11y_panel <- function() {
         column(
           width = 12,
           h1("Accessibility statement"),
-          br("This website is run by the", a(href = "https://www.gov.uk/government/organisations/department-for-education", "Department for Education (DfE).", ""), 
-             "We want as many people as possible to be able to use this website. 
-             For example, that means you should be able to:"),
+          br(
+            "This website is run by the", a(href = "https://www.gov.uk/government/organisations/department-for-education", "Department for Education (DfE).", ""),
+            "We want as many people as possible to be able to use this website.
+             For example, that means you should be able to:"
+          ),
           tags$div(tags$ul(
             tags$li("change colours, contrast levels and fonts"),
             tags$li("zoom in up to 300% without the text spilling off the screen"),
@@ -24,28 +26,32 @@ a11y_panel <- function() {
             tags$li("list them here")
           )),
           h2("What to do if you cannot access parts of this website"),
-          br("If you need information on this website in a different format like accessible PDF, 
-             large print, easy read, audio recording or braille, email"), 
-          br((a(href="mailto:explore.statistics@education.gov.uk", "explore.statistics@education.gov.uk", ""))),
+          br("If you need information on this website in a different format like accessible PDF,
+             large print, easy read, audio recording or braille, email"),
+          br((a(href = "mailto:explore.statistics@education.gov.uk", "explore.statistics@education.gov.uk", ""))),
           h2("Reporting accessibility problems with this website"),
-          br("We’re always looking to improve the accessibility of this website. 
+          br("We’re always looking to improve the accessibility of this website.
              If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact us:"),
-          br((a(href="mailto:explore.statistics@education.gov.uk", "explore.statistics@education.gov.uk", ""))),
+          br((a(href = "mailto:explore.statistics@education.gov.uk", "explore.statistics@education.gov.uk", ""))),
           h2("Technical information about this website's accessibility"),
-          br("The Department for Education (DfE) is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) 
+          br(
+            "The Department for Education (DfE) is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications)
               (No. 2) Accessibility Regulations 2018.
               This website is partially compliant with the", a(href = "https://www.w3.org/TR/WCAG21/", "Web Content Accessibility Guidelines version 2.1 AA standard", ""),
-             " due to the non-compliances listed below."),
+            " due to the non-compliances listed below."
+          ),
           h2("Non accessible content"),
-          br("The content listed below is non-accessible for the following reasons. 
+          br("The content listed below is non-accessible for the following reasons.
              We will address these issues to ensure our content is accessible."),
           tags$div(tags$ul(
             tags$li("list them here")
           )),
           h2("How we tested this website"),
-          br("This website was last tested on 27 September 2022 against", a(href = "https://www.w3.org/TR/WCAG21/", "Accessibility Guidelines WCAG2.1.", ""), 
-              "The test was carried out by the", a(href="https://digitalaccessibilitycentre.org/", "Digital accessibility centre (DAC).", ""),
-              "DAC tested a sample of pages to cover the core functionality of the service including:"),
+          br(
+            "This website was last tested on 27 September 2022 against", a(href = "https://www.w3.org/TR/WCAG21/", "Accessibility Guidelines WCAG2.1.", ""),
+            "The test was carried out by the", a(href = "https://digitalaccessibilitycentre.org/", "Digital accessibility centre (DAC).", ""),
+            "DAC tested a sample of pages to cover the core functionality of the service including:"
+          ),
           tags$div(tags$ul(
             tags$li("list them here")
           )),

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.3",
+    "Version": "4.4.1",
     "Repositories": [
       {
         "Name": "CRAN",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -6,7 +6,9 @@ local({
   attr(version, "sha") <- NULL
 
   # the project directory
-  project <- getwd()
+  project <- Sys.getenv("RENV_PROJECT")
+  if (!nzchar(project))
+    project <- getwd()
 
   # use start-up diagnostics if enabled
   diagnostics <- Sys.getenv("RENV_STARTUP_DIAGNOSTICS", unset = "FALSE")
@@ -31,6 +33,14 @@ local({
     if (!is.null(override))
       return(override)
 
+    # if we're being run in a context where R_LIBS is already set,
+    # don't load -- presumably we're being run as a sub-process and
+    # the parent process has already set up library paths for us
+    rcmd <- Sys.getenv("R_CMD", unset = NA)
+    rlibs <- Sys.getenv("R_LIBS", unset = NA)
+    if (!is.na(rlibs) && !is.na(rcmd))
+      return(FALSE)
+
     # next, check environment variables
     # TODO: prefer using the configuration one in the future
     envvars <- c(
@@ -50,8 +60,21 @@ local({
 
   })
 
-  if (!enabled)
+  # bail if we're not enabled
+  if (!enabled) {
+
+    # if we're not enabled, we might still need to manually load
+    # the user profile here
+    profile <- Sys.getenv("R_PROFILE_USER", unset = "~/.Rprofile")
+    if (file.exists(profile)) {
+      cfg <- Sys.getenv("RENV_CONFIG_USER_PROFILE", unset = "TRUE")
+      if (tolower(cfg) %in% c("true", "t", "1"))
+        sys.source(profile, envir = globalenv())
+    }
+
     return(FALSE)
+
+  }
 
   # avoid recursion
   if (identical(getOption("renv.autoloader.running"), TRUE)) {
@@ -105,6 +128,21 @@ local({
   
     tail <- paste(rep.int(suffix, n), collapse = "")
     paste0(prefix, " ", label, " ", tail)
+  
+  }
+  
+  heredoc <- function(text, leave = 0) {
+  
+    # remove leading, trailing whitespace
+    trimmed <- gsub("^\\s*\\n|\\n\\s*$", "", text)
+  
+    # split into lines
+    lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]
+  
+    # compute common indent
+    indent <- regexpr("[^[:space:]]", lines)
+    common <- min(setdiff(indent, -1L)) - leave
+    paste(substring(lines, common), collapse = "\n")
   
   }
   
@@ -610,6 +648,9 @@ local({
   
     # if the user has requested an automatic prefix, generate it
     auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
+    if (is.na(auto) && getRversion() >= "4.4.0")
+      auto <- "TRUE"
+  
     if (auto %in% c("TRUE", "True", "true", "1"))
       return(renv_bootstrap_platform_prefix_auto())
   
@@ -801,24 +842,23 @@ local({
   
     # the loaded version of renv doesn't match the requested version;
     # give the user instructions on how to proceed
-    remote <- if (!is.null(description[["RemoteSha"]])) {
+    dev <- identical(description[["RemoteType"]], "github")
+    remote <- if (dev)
       paste("rstudio/renv", description[["RemoteSha"]], sep = "@")
-    } else {
+    else
       paste("renv", description[["Version"]], sep = "@")
-    }
   
     # display both loaded version + sha if available
     friendly <- renv_bootstrap_version_friendly(
       version = description[["Version"]],
-      sha     = description[["RemoteSha"]]
+      sha     = if (dev) description[["RemoteSha"]]
     )
   
-    fmt <- paste(
-      "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
-      "- Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
-      "- Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
-      sep = "\n"
-    )
+    fmt <- heredoc("
+      renv %1$s was loaded from project library, but this project is configured to use renv %2$s.
+      - Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.
+      - Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.
+    ")
     catf(fmt, friendly, renv_bootstrap_version_friendly(version), remote)
   
     FALSE
@@ -1041,7 +1081,7 @@ local({
     # if jsonlite is loaded, use that instead
     if ("jsonlite" %in% loadedNamespaces()) {
   
-      json <- catch(renv_json_read_jsonlite(file, text))
+      json <- tryCatch(renv_json_read_jsonlite(file, text), error = identity)
       if (!inherits(json, "error"))
         return(json)
   
@@ -1050,7 +1090,7 @@ local({
     }
   
     # otherwise, fall back to the default JSON reader
-    json <- catch(renv_json_read_default(file, text))
+    json <- tryCatch(renv_json_read_default(file, text), error = identity)
     if (!inherits(json, "error"))
       return(json)
   
@@ -1063,14 +1103,14 @@ local({
   }
   
   renv_json_read_jsonlite <- function(file = NULL, text = NULL) {
-    text <- paste(text %||% read(file), collapse = "\n")
+    text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     jsonlite::fromJSON(txt = text, simplifyVector = FALSE)
   }
   
   renv_json_read_default <- function(file = NULL, text = NULL) {
   
     # find strings in the JSON
-    text <- paste(text %||% read(file), collapse = "\n")
+    text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
     locs <- gregexpr(pattern, text, perl = TRUE)[[1]]
   
@@ -1118,14 +1158,14 @@ local({
     map <- as.list(map)
   
     # remap strings in object
-    remapped <- renv_json_remap(json, map)
+    remapped <- renv_json_read_remap(json, map)
   
     # evaluate
     eval(remapped, envir = baseenv())
   
   }
   
-  renv_json_remap <- function(json, map) {
+  renv_json_read_remap <- function(json, map) {
   
     # fix names
     if (!is.null(names(json))) {
@@ -1152,7 +1192,7 @@ local({
     # recurse
     if (is.recursive(json)) {
       for (i in seq_along(json)) {
-        json[i] <- list(renv_json_remap(json[[i]], map))
+        json[i] <- list(renv_json_read_remap(json[[i]], map))
       }
     }
   


### PR DESCRIPTION
As discussed, I have rewritten the accessibility statement to match the EES one:

[https://explore-education-statistics.service.gov.uk/accessibility-statement](https://explore-education-statistics.service.gov.uk/accessibility-statement)

There are some gaps for things to be added in (e.g. github issues that are going to be resolved in future) but the overall structure is hopefully there! 

The idea is to have this as an example to show other teams, and then we work 1:1 with teams to help them write bespoke accessibility statements for their dashboards because I think people find it too scary to write/edit the template one on their own. 

