### PR TITLE
Fix title tag

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -60,14 +60,10 @@
 ui <- function(input, output, session) {
   fluidPage(
     # use_tota11y(),
-    title = tags$head(
-      tags$link(
-        rel = "shortcut icon",
-        href = "dfefavicon.png"
-      ),
-      # Add title for browser tabs
-      tags$head(HTML("<title>Department for Education (DfE) Shiny Template</title>"))
-    ),
+
+    # Set application metadata ------------------------------------------------
+    tags$head(HTML("<title>Department for Education (DfE) Shiny Template</title>")),
+    tags$head(tags$link(rel = "shortcut icon", href = "dfefavicon.png")),
     use_shiny_title(),
     tags$html(lang = "en"),
     # Add meta description for search engines

--- a/ui.R
+++ b/ui.R
@@ -66,7 +66,7 @@ ui <- function(input, output, session) {
         href = "dfefavicon.png"
       ),
       # Add title for browser tabs
-      tags$title("Department for Education (DfE) Shiny Template")
+      tags$head(HTML("<title>Department for Education (DfE) Shiny Template</title>"))
     ),
     use_shiny_title(),
     tags$html(lang = "en"),


### PR DESCRIPTION
## Pull request overview

Flagged in the accessibility audit that the current title isn't appearing.

## Pull request checklist

Please check if your PR fulfils the following:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)

## What is the current behaviour?

Currently you get a blank confused title

![image](https://github.com/user-attachments/assets/8163ba77-9dbb-4e85-9395-6b1a9519cf6a)


## What is the new behaviour?

The title pulls through, there's no extra blank title

![image](https://github.com/user-attachments/assets/554bc5d6-9fba-48d4-b1c3-17f4a7ca9629)

## Anything else

Prompted in part by our conversation this morning @jen-machin 