### PR TITLE
Extend data file suffix check in commit hooks

### DIFF
--- a/.hooks/pre-commit.R
+++ b/.hooks/pre-commit.R
@@ -35,7 +35,7 @@ if (ncol(ign_files) > 1) {
 suffixes <- "xlsx$|ods$|dat$|csv$|tex$|pdf$|zip$|gz$|parquet$"
 
 current_files <- data.frame(files = list.files("./", recursive = TRUE)) %>%
-  filter(grepl(suffixes, files), !grepl("renv|datafiles_log.csv", files))
+  filter(grepl(suffixes, files, ignore.case = TRUE), !grepl("renv|datafiles_log.csv", files))
 
 for (file in current_files$files) {
   if (!file %in% log_files$filename) {

--- a/.hooks/pre-commit.R
+++ b/.hooks/pre-commit.R
@@ -32,7 +32,7 @@ if (ncol(ign_files) > 1) {
   }
 }
 
-suffixes <- "xlsx$|ods$|dat$|csv$|tex$|pdf$|zip$|gz$|parquet$"
+suffixes <- "xlsx$|ods$|dat$|csv$|tex$|pdf$|zip$|gz$|parquet$|rda$|rds$"
 
 current_files <- data.frame(files = list.files("./", recursive = TRUE)) %>%
   filter(grepl(suffixes, files, ignore.case = TRUE), !grepl("renv|datafiles_log.csv", files))

--- a/.hooks/pre-commit.R
+++ b/.hooks/pre-commit.R
@@ -32,7 +32,7 @@ if (ncol(ign_files) > 1) {
   }
 }
 
-suffixes <- "xlsx$|dat$|csv$|tex$|pdf$"
+suffixes <- "xlsx$|ods$|dat$|csv$|tex$|pdf$|zip$|gz$|parquet$"
 
 current_files <- data.frame(files = list.files("./", recursive = TRUE)) %>%
   filter(grepl(suffixes, files), !grepl("renv|datafiles_log.csv", files))


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [x] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

The commit hooks don't check for a range of possible data file types:
- parquet
- ods
- zip
- gz
- rds
- rda

## What is the new behaviour?

The commit hooks now check for all the above file types (in addition to csv, xlsx, etc) and refuses to commit if they're not explictly logged in the data log file.

## Anything else

Resolves #92 