### PR TITLE
Select multi false

### DIFF
--- a/R/ui_panels/example_tab_1.R
+++ b/R/ui_panels/example_tab_1.R
@@ -156,11 +156,18 @@ example_tab_1_panel <- function() {
                              overflow-y: visible;
                              margin-bottom: 10px;", # Adjusted margin
                     selectizeInput(
-                      "selectBenchLAs",
-                      "Select benchmark local authorities",
-                      choices = choices_las$area_name,
-                      multiple = TRUE,
-                      options = list(maxItems = 3)
+                      "selectBenchLAs1",
+                      "Select benchmark local authorities (1)",
+                      choices = c("", choices_las$area_name),
+                      multiple = FALSE,
+                      selected = NULL
+                    ),
+                    selectizeInput(
+                      "selectBenchLAs2",
+                      "Select benchmark local authorities (2)",
+                      choices = c("", choices_las$area_name),
+                      multiple = FALSE,
+                      selected = NULL
                     )
                   ),
                   h2("An Example Reactable"),

--- a/server.R
+++ b/server.R
@@ -210,7 +210,11 @@ server <- function(input, output, session) {
   reactive_benchmark <- reactive({
     df_revbal %>%
       filter(
-        area_name %in% c(input$selectArea, input$selectBenchLAs),
+        area_name %in% c(
+          input$selectArea,
+          input$selectBenchLAs1,
+          input$selectBenchLAs2
+        ),
         school_phase == input$selectPhase,
         year == max(year)
       )

--- a/server.R
+++ b/server.R
@@ -220,6 +220,22 @@ server <- function(input, output, session) {
       )
   })
 
+  observe({
+    updateSelectizeInput(session,
+      "selectBenchLAs2",
+      choices = c("", choices_las$area_name[choices_las$area_name != input$selectBenchLAs1]),
+      selected = isolate(input$selectBenchLAs2)
+    )
+  })
+
+  observe({
+    updateSelectizeInput(session,
+      "selectBenchLAs1",
+      choices = c("", choices_las$area_name[choices_las$area_name != input$selectBenchLAs2]),
+      selected = isolate(input$selectBenchLAs1)
+    )
+  })
+
   # Charts --------------------------------------------------------------------
   # Line chart for revenue balance over time
 


### PR DESCRIPTION
<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

## Pull request overview

Change selectizeInput to have multiple = FALSE

...

## Pull request checklist

Please check if your PR fulfills the following:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [ ] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

Multiple = TRUE

...


## What is the new behaviour?

Multiple = FALSE and a second input to still allow for comparison of up to three areas

...

## Anything else

To resolve issue #121 

...
