### PR TITLE
Updated template automated test to point to dfeshiny workflow

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-  
   pull_request:
       
 name: Automated tests

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -8,4 +8,4 @@ name: Automated tests
 
 jobs:
   automatedTests:
-    uses: dfe-analytical-services/dfeshiny/.github/workflows/automated_tests_template.yaml@bugfix/automated-test-workflow
+    uses: dfe-analytical-services/dfeshiny/.github/workflows/automated_tests_template.yaml@main

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -9,46 +9,4 @@ name: Automated tests
 
 jobs:
   automatedTests:
-    runs-on: ubuntu-latest
-    
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-     
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          
-      - name: Install git2r dependencies
-        run: sudo apt-get install -y libgit2-dev
-
-      - name: Install proj library (terra depdencies)
-        run: sudo apt-get install libproj-dev
-        
-      - name: Install gdal library (terra dependencies)
-        run: sudo apt-get install libgdal-dev
-        
-      - name: Install udunits library (units dependencies)
-        run: sudo apt-get install libudunits2-dev
-
-      - name: Cache renv packages
-        id: cache-renv
-        uses: actions/cache@v4
-        with:
-          path: cache-renv
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-renv-
-      
-      - uses: r-lib/actions/setup-renv@v2
-          
-      - name: Set Chromote to new headless mode
-        run: export CHROMOTE_HEADLESS="new"
-
-      - name: Run tests 
-        shell: Rscript {0}
-        run: |
-          shinytest2::test_app()
-          
+    uses: dfe-analytical-services/dfeshiny/.github/workflows/automated_tests_template.yaml@bugfix/automated-test-workflow

--- a/.github/workflows/create-trello-ticket.yaml
+++ b/.github/workflows/create-trello-ticket.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   create-card:
-    uses: dfe-analytical-services/dfeshiny/.github/workflows/create_trello_card_template.yaml@new-feature/trello-pr-workflow
+    uses: dfe-analytical-services/dfeshiny/.github/workflows/create_trello_card_template.yaml@main
     secrets:
       TRELLO_API_KEY: '${{ secrets.TRELLO_API_KEY }}'
       TRELLO_API_TOKEN: '${{ secrets.TRELLO_API_TOKEN }}'

--- a/global.R
+++ b/global.R
@@ -52,6 +52,7 @@ shhh(library(shinyalert))
 # them, saving on load time.
 if (FALSE) {
   shhh(library(shinytest2))
+  shhh(library(chromote))
   shhh(library(testthat))
 }
 

--- a/renv.lock
+++ b/renv.lock
@@ -179,47 +179,7 @@
     "Matrix": {
       "Package": "Matrix",
       "Version": "1.7-2",
-      "Source": "Repository",
-      "VersionNote": "do also bump src/version.h, inst/include/Matrix/version.h",
-      "Date": "2025-01-20",
-      "Priority": "recommended",
-      "Title": "Sparse and Dense Matrix Classes and Methods",
-      "Description": "A rich hierarchy of sparse and dense matrix classes, including general, symmetric, triangular, and diagonal matrices with numeric, logical, or pattern entries.  Efficient methods for operating on such matrices, often wrapping the 'BLAS', 'LAPACK', and 'SuiteSparse' libraries.",
-      "License": "GPL (>= 2) | file LICENCE",
-      "URL": "https://Matrix.R-forge.R-project.org",
-      "BugReports": "https://R-forge.R-project.org/tracker/?atid=294&group_id=61",
-      "Contact": "Matrix-authors@R-project.org",
-      "Authors@R": "c(person(\"Douglas\", \"Bates\", role = \"aut\", comment = c(ORCID = \"0000-0001-8316-9503\")), person(\"Martin\", \"Maechler\", role = c(\"aut\", \"cre\"), email = \"mmaechler+Matrix@gmail.com\", comment = c(ORCID = \"0000-0002-8685-9910\")), person(\"Mikael\", \"Jagan\", role = \"aut\", comment = c(ORCID = \"0000-0002-3542-2938\")), person(\"Timothy A.\", \"Davis\", role = \"ctb\", comment = c(ORCID = \"0000-0001-7614-6899\", \"SuiteSparse libraries\", \"collaborators listed in dir(system.file(\\\"doc\\\", \\\"SuiteSparse\\\", package=\\\"Matrix\\\"), pattern=\\\"License\\\", full.names=TRUE, recursive=TRUE)\")), person(\"George\", \"Karypis\", role = \"ctb\", comment = c(ORCID = \"0000-0003-2753-1437\", \"METIS library\", \"Copyright: Regents of the University of Minnesota\")), person(\"Jason\", \"Riedy\", role = \"ctb\", comment = c(ORCID = \"0000-0002-4345-4200\", \"GNU Octave's condest() and onenormest()\", \"Copyright: Regents of the University of California\")), person(\"Jens\", \"Oehlschlägel\", role = \"ctb\", comment = \"initial nearPD()\"), person(\"R Core Team\", role = \"ctb\", comment = c(ROR = \"02zz1nj61\", \"base R's matrix implementation\")))",
-      "Depends": [
-        "R (>= 4.4)",
-        "methods"
-      ],
-      "Imports": [
-        "grDevices",
-        "graphics",
-        "grid",
-        "lattice",
-        "stats",
-        "utils"
-      ],
-      "Suggests": [
-        "MASS",
-        "datasets",
-        "sfsmisc",
-        "tools"
-      ],
-      "Enhances": [
-        "SparseM",
-        "graph"
-      ],
-      "LazyData": "no",
-      "LazyDataNote": "not possible, since we use data/*.R and our S4 classes",
-      "BuildResaveData": "no",
-      "Encoding": "UTF-8",
-      "NeedsCompilation": "yes",
-      "Author": "Douglas Bates [aut] (<https://orcid.org/0000-0001-8316-9503>), Martin Maechler [aut, cre] (<https://orcid.org/0000-0002-8685-9910>), Mikael Jagan [aut] (<https://orcid.org/0000-0002-3542-2938>), Timothy A. Davis [ctb] (<https://orcid.org/0000-0001-7614-6899>, SuiteSparse libraries, collaborators listed in dir(system.file(\"doc\", \"SuiteSparse\", package=\"Matrix\"), pattern=\"License\", full.names=TRUE, recursive=TRUE)), George Karypis [ctb] (<https://orcid.org/0000-0003-2753-1437>, METIS library, Copyright: Regents of the University of Minnesota), Jason Riedy [ctb] (<https://orcid.org/0000-0002-4345-4200>, GNU Octave's condest() and onenormest(), Copyright: Regents of the University of California), Jens Oehlschlägel [ctb] (initial nearPD()), R Core Team [ctb] (02zz1nj61, base R's matrix implementation)",
-      "Maintainer": "Martin Maechler <mmaechler+Matrix@gmail.com>",
-      "Repository": "CRAN"
+      "Source": "Repository"
     },
     "R.cache": {
       "Package": "R.cache",
@@ -839,8 +799,8 @@
     },
     "chromote": {
       "Package": "chromote",
-      "Version": "0.4.0",
-      "Source": "Repository",
+      "Version": "0.4.0.9000",
+      "Source": "GitHub",
       "Title": "Headless Chrome Web Browser Interface",
       "Authors@R": "c( person(\"Winston\", \"Chang\", , \"winston@posit.co\", role = c(\"aut\", \"cre\")), person(\"Barret\", \"Schloerke\", , \"barret@posit.co\", role = \"aut\", comment = c(ORCID = \"0000-0001-9986-114X\")), person(\"Garrick\", \"Aden-Buie\", , \"garrick@posit.co\", role = \"aut\", comment = c(ORCID = \"0000-0002-7111-0077\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
       "Description": "An implementation of the 'Chrome DevTools Protocol', for controlling a headless Chrome web browser.",
@@ -848,6 +808,7 @@
       "URL": "https://rstudio.github.io/chromote/, https://github.com/rstudio/chromote",
       "BugReports": "https://github.com/rstudio/chromote/issues",
       "Imports": [
+        "cli",
         "curl",
         "fastmap",
         "jsonlite",
@@ -856,24 +817,36 @@
         "processx",
         "promises (>= 1.1.1)",
         "R6",
-        "rlang",
+        "rlang (>= 1.1.0)",
         "utils",
-        "websocket (>= 1.2.0)"
+        "websocket (>= 1.2.0)",
+        "withr",
+        "zip"
       ],
       "Suggests": [
+        "knitr",
+        "rmarkdown",
         "showimage",
         "testthat (>= 3.0.0)"
       ],
       "Config/Needs/website": "tidyverse/tidytemplate",
       "Config/testthat/edition": "3",
+      "Config/testthat/parallel": "TRUE",
+      "Config/testthat/start-first": "chromote_session",
       "Encoding": "UTF-8",
       "Language": "en-US",
+      "Roxygen": "list(markdown = TRUE)",
       "RoxygenNote": "7.3.2",
       "SystemRequirements": "Google Chrome or other Chromium-based browser. chromium: chromium (rpm) or chromium-browser (deb)",
-      "NeedsCompilation": "no",
+      "VignetteBuilder": "knitr",
       "Author": "Winston Chang [aut, cre], Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>), Garrick Aden-Buie [aut] (<https://orcid.org/0000-0002-7111-0077>), Posit Software, PBC [cph, fnd]",
       "Maintainer": "Winston Chang <winston@posit.co>",
-      "Repository": "CRAN"
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "rstudio",
+      "RemoteRepo": "chromote",
+      "RemoteRef": "main",
+      "RemoteSha": "6c6cf666300250b8e37a41ee55eb2e5b11ee2c2b"
     },
     "class": {
       "Package": "class",
@@ -1426,7 +1399,7 @@
       "RemoteUsername": "dfe-analytical-services",
       "RemoteRepo": "dfeshiny",
       "RemoteRef": "main",
-      "RemoteSha": "6086d4e350890790b52e74292f7aff716f206802",
+      "RemoteSha": "6c40e65425cb0198c329a8ab7b4bfe7d2772550e",
       "RemoteHost": "api.github.com"
     },
     "diffobj": {
@@ -4565,11 +4538,11 @@
       "Author": "Ross Wyatt [aut, cre], Cameron Race [ctb], Sarah Wong [ctb], Richard Bielby [ctb], Charlotte Foster [ctb], Jeni Martin [ctb]",
       "Maintainer": "Ross Wyatt <ross.wyatt@justice.gov.uk>",
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
       "RemoteUsername": "dfe-analytical-services",
       "RemoteRepo": "shinyGovstyle",
       "RemoteRef": "master",
-      "RemoteSha": "66357f5c8ed197dd95bebf0689ed70d2efa5b958"
+      "RemoteSha": "cf93f0acfd68b2bdf6b04bc4fa2e6a016a5e72cf",
+      "RemoteHost": "api.github.com"
     },
     "shinyalert": {
       "Package": "shinyalert",
@@ -5422,7 +5395,7 @@
     },
     "units": {
       "Package": "units",
-      "Version": "0.8-6",
+      "Version": "0.8-7",
       "Source": "Repository",
       "Title": "Measurement Units for R Vectors",
       "Authors@R": "c(person(\"Edzer\", \"Pebesma\", role = c(\"aut\", \"cre\"), email = \"edzer.pebesma@uni-muenster.de\", comment = c(ORCID = \"0000-0001-8049-7069\")), person(\"Thomas\", \"Mailund\", role = \"aut\", email = \"mailund@birc.au.dk\"), person(\"Tomasz\", \"Kalinowski\", role = \"aut\"), person(\"James\", \"Hiebert\", role = \"ctb\"), person(\"Iñaki\", \"Ucar\", role = \"aut\", email = \"iucar@fedoraproject.org\", comment = c(ORCID = \"0000-0001-6403-5550\")), person(\"Thomas Lin\", \"Pedersen\", role = \"ctb\") )",


### PR DESCRIPTION
## Pull request overview

dfeshiny now has a template workflow for the automated tests. Just updating the template app to point to the current development version of that workflow. Using it to test something on a side branch in dfeshiny, but then will switch it to main once I've tested that.

## Pull request checklist

Please check if your PR fulfills the following:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [ ] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

Uses standalone workflow

## What is the new behaviour?

Uses standard dfeshiny workflow template

## Anything else

Could do with these changes so tests are all working on other PRs coming through in dfeshiny

I had some odd issues with running the tests on docker around special characters. Figured out it was to do with locale settings and that the Docker was of course defaulting to en_US. As part of this work, I've switched the Docker image to be set up with en_GB instead:

https://github.com/dfe-analytical-services/DFE-Docker/commit/7b4adbc4788d458ccfe90db66f71ac41a1df96a2
